### PR TITLE
Filter abi jar from jdeps classpath

### DIFF
--- a/kotlin/internal/jvm/associates.bzl
+++ b/kotlin/internal/jvm/associates.bzl
@@ -95,6 +95,11 @@ def _get_associates(ctx, toolchains, associates):
             dep_infos = java_infos,
         )
 
+def _filter_abi_associate_jar(transitive, associates):
+    compile_depset_list = depset(transitive = transitive).to_list()
+    return [jar for jar in compile_depset_list if not _sets.contains(associates.abi_jar_set, jar)]
+
 associate_utils = struct(
     get_associates = _get_associates,
+    filter_abi_associate_jar = _filter_abi_associate_jar,
 )

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -114,9 +114,6 @@ def _fail_if_invalid_associate_deps(associate_deps, deps):
             ",\n ".join(["    %s" % x for x in list(diff)]),
         )
 
-def _java_infos_to_compile_jars(java_infos):
-    return depset(transitive = [j.compile_jars for j in java_infos])
-
 def _exported_plugins(deps):
     """Encapsulates compiler dependency metadata."""
     plugins = []
@@ -469,7 +466,7 @@ def _run_kt_builder_action(
     # Unwrap kotlinc_options/javac_options options or default to the ones being provided by the toolchain
     args.add_all("--kotlin_passthrough_flags", kotlinc_options_to_flags(kotlinc_options))
     args.add_all("--javacopts", javac_options_to_flags(javac_options))
-    args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))
+    args.add_all("--direct_dependencies", compile_deps.direct_dep_jars)
     args.add("--strict_kotlin_deps", toolchains.kt.experimental_strict_kotlin_deps)
     args.add_all("--classpath", compile_deps.compile_jars)
     args.add("--reduced_classpath_mode", toolchains.kt.experimental_reduce_classpath_mode)

--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -16,7 +16,6 @@ load(
     "JavaInfo",
 )
 load("//kotlin/internal/jvm:associates.bzl", _associate_utils = "associate_utils")
-load("//kotlin/internal/utils:sets.bzl", _sets = "sets")
 
 def _java_info(target):
     return target[JavaInfo] if JavaInfo in target else None
@@ -35,24 +34,30 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
         [_java_info(d) for d in deps]
     )
 
+    direct_dep_jars = [associates.jars] + [
+        d.compile_jars
+        for d in dep_infos
+    ]
+
     # Reduced classpath, exclude transitive deps from compilation
     if (toolchains.kt.experimental_prune_transitive_deps and
         not "kt_experimental_prune_transitive_deps_incompatible" in ctx.attr.tags):
-        transitive = [
-            d.compile_jars
-            for d in dep_infos
-        ]
+        transitive = direct_dep_jars
     else:
-        transitive = [
-            d.compile_jars
-            for d in dep_infos
-        ] + [
+        transitive = direct_dep_jars + [
             d.transitive_compile_time_jars
             for d in dep_infos
         ]
 
-    compile_depset_list = depset(transitive = transitive + [associates.jars]).to_list()
-    compile_depset_list_filtered = [jar for jar in compile_depset_list if not _sets.contains(associates.abi_jar_set, jar)]
+    compile_depset_list_filtered = _associate_utils.filter_abi_associate_jar(transitive, associates)
+
+    if (toolchains.kt.experimental_prune_transitive_deps and
+        not "kt_experimental_prune_transitive_deps_incompatible" in ctx.attr.tags):
+        # then compile_depset_list_filtered already contains just the compile jars
+        direct_depset_list_filtered = compile_depset_list_filtered
+    else:
+        # otherwise we need to create a list of compile jars with the associates abi jar replaced
+        direct_depset_list_filtered = _associate_utils.filter_abi_associate_jar(direct_dep_jars, associates)
 
     return struct(
         module_name = associates.module_name,
@@ -61,6 +66,7 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
         associate_jars = associates.jars,
         compile_jars = depset(direct = compile_depset_list_filtered),
         runtime_deps = [_java_info(d) for d in runtime_deps],
+        direct_dep_jars = direct_depset_list_filtered,
     )
 
 jvm_deps_utils = struct(


### PR DESCRIPTION
Following on from [#1337](https://github.com/bazelbuild/rules_kotlin/pull/1337) (a particularly l33t PR), it was noticed that the `--direct_dependencies` (used for the jdeps compiler plugin) include the ABI jar for an associate when instead the runtime class jar should be used.

This is a proposal to remedy this, instead of [generating](https://github.com/bazelbuild/rules_kotlin/pull/1340/files#diff-ca072bf9da461834e9b015042cb38ba7d06b7977889bc1956b4da376b9df2512L472) a list of compile jars from the targets deps at the point of compiler flag generation. This list is [pre-generated](https://github.com/bazelbuild/rules_kotlin/pull/1340/files#diff-16bd765ba02398058bd856317b38e6baa035de90e54c1b12bcfa05567abb3dd0R69) in the jvm_deps functions where the abi jar can be filtered out.

It turns out that this list is identical to the compile_jars list when experimental_prune_transitive_deps is enabled, so when this stops being experimental things should get much simpler.