### PR TITLE
fix: skip plugins without processor_classes in annotation processor classification

### DIFF
--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -40,11 +40,11 @@ def _targets_to_annotation_processors(targets):
             pass
         elif JavaPluginInfo in t:
             p = t[JavaPluginInfo].plugins
-            if p.processor_jars:
+            if p.processor_jars and p.processor_classes.to_list():
                 plugins.append(p)
         elif JavaInfo in t:
             p = t[JavaInfo].plugins
-            if p.processor_jars:
+            if p.processor_jars and p.processor_classes.to_list():
                 plugins.append(p)
 
     return plugins


### PR DESCRIPTION
## Problem

Non-annotation-processor plugins are being misclassified as annotation processors.

Context:
We are using `kt_jvm_library` with mixed Java/Kotlin sources, and we want to use Error Prone as a `java_plugin` via the `plugins` attribute, so that Error Prone runs as a `javac` plugin on the Java sources.

Problem:
When no annotation processors are passed in, and Error Prone is passed, running `bazel build <target>` fails on `javac` step, throwing
`error: package <package> does not exist` and `error: cannot find symbol` errors on Kotlin pkgs/symbols.

An Error Prone `java_plugin` has `processor_jars` but no `processor_classes`. However, `_targets_to_annotation_processors` includes it because it only checks for `processor_jars`, misclassifying it as an annotation processor.

This causes:
1. KAPT is triggered but the `src_main-kapt-generated-stub.jar
` in `kt_stubs_for_java` is empty (since there were no real processors to generate stubs). [Code reference](https://github.com/bazel-contrib/rules_kotlin/blob/4eb4b2302662f7a78620fee3cefdfa9031896a1c/kotlin/internal/jvm/compile.bzl#L888-L909).
2. The [Kotlin compile jar](https://github.com/bazel-contrib/rules_kotlin/blob/4eb4b2302662f7a78620fee3cefdfa9031896a1c/kotlin/internal/jvm/compile.bzl#L968-L969) is not added to `kt_stubs_for_java` (`compile.bzl:968`). It is only populated when `annotation_processors` is empty (given Kotlin sources are present).
3. When [building Java](https://github.com/bazel-contrib/rules_kotlin/blob/4eb4b2302662f7a78620fee3cefdfa9031896a1c/kotlin/internal/jvm/compile.bzl#L999-L1004), Java sources that reference Kotlin symbols fail with missing symbols errors.

In Bazel, `java_plugin` covers both annotation processors (declare `processor_class`) and javac plugins like Error Prone (no `processor_class`). Only the former should go through KAPT.

Note that: if both ErrorProne and an annotator processor are provided, this issue does not happen.

## Fix

In `_targets_to_annotation_processors` (`kotlin/internal/jvm/plugins.bzl`), also require `processor_classes` to be non-empty:

```python
- if p.processor_jars:
+ if p.processor_jars and p.processor_classes.to_list():
```

Error Prone is still picked up correctly as a javac plugin via the `plugins` attribute in `_run_kt_builder_action`, it just no longer incorrectly triggers KAPT and not passing `kt_stubs_for_java`.

## Testing

- `bazel test //src/...`