### PR TITLE
Print BTAPI compiler errors and diagnostics to stderr stream

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -392,7 +392,15 @@ fun JvmCompilationTask.compileKotlin(
           options = inputs.compilerPluginOptionsList,
           classpath = inputs.compilerPluginClasspathList,
         )
-    ).list()
+    ).let { compilationArgs ->
+      // Request '-verbose' execution for BTAPI compiler if tracing is enabled
+      val tracing = context.whenTracing { true } == true
+      if (info.buildToolsApi && tracing && "-verbose" !in compilationArgs.args) {
+        compilationArgs.flag("-verbose")
+      } else {
+        compilationArgs
+      }
+    }.list()
       .let {
         context.whenTracing {
           context.printLines("compileKotlin arguments:\n", it)

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
@@ -17,6 +17,7 @@ package io.bazel.kotlin.compiler
 
 import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
 import org.jetbrains.kotlin.buildtools.api.getToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
@@ -52,7 +53,10 @@ class BuildToolsAPICompiler : KotlinCompiler {
     // Execute the compilation
     val result =
       kotlinToolchains.createBuildSession().use { session ->
-        session.executeOperation(operationBuilder.build())
+        session.executeOperation(
+          operationBuilder.build(),
+          logger = createLogger(errStream, verbose = "-verbose" in args),
+        )
       }
 
     // BTAPI returns a different type than K2JVMCompiler (CompilationResult vs ExitCode).
@@ -63,4 +67,46 @@ class BuildToolsAPICompiler : KotlinCompiler {
       CompilationResult.COMPILER_INTERNAL_ERROR -> ExitCode.INTERNAL_ERROR
     }
   }
+
+  private fun createLogger(
+    out: PrintStream,
+    verbose: Boolean,
+  ): KotlinLogger =
+    object : KotlinLogger {
+      override val isDebugEnabled: Boolean = verbose
+
+      override fun error(
+        msg: String,
+        throwable: Throwable?,
+      ) {
+        out.println(msg)
+        throwable?.printStackTrace(out)
+      }
+
+      override fun warn(
+        msg: String,
+        throwable: Throwable?,
+      ) {
+        out.println(msg)
+        throwable?.printStackTrace(out)
+      }
+
+      override fun info(msg: String) {
+        if (verbose) {
+          out.println(msg)
+        }
+      }
+
+      override fun debug(msg: String) {
+        if (verbose) {
+          out.println(msg)
+        }
+      }
+
+      override fun lifecycle(msg: String) {
+        if (verbose) {
+          out.println(msg)
+        }
+      }
+    }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.google.common.truth.Truth.assertThat;
+
 /** Compiles through the Build Tools API path ({@code --build_tools_api=true}). */
 @RunWith(JUnit4.class)
 public class KotlinBuilderJvmBtaTest {
@@ -58,5 +60,38 @@ public class KotlinBuilderJvmBtaTest {
                     c.outputJdeps();
                 });
         ctx.assertFilesExist(DirectoryType.CLASSES, "something/AClass.class");
+    }
+
+    @Test
+    public void testVerboseOutputIsReported() {
+        // The tracing mode enabled by 'compileKotlin()' is mapped to compiler's -verbose flag, which enables task output to stderr
+        ctx.runCompileTask(
+                c -> {
+                    c.useBuildToolsApi();
+                    c.compileKotlin();
+                    c.addSource("AClass.kt", "package something;" + "class AClass{}");
+                    c.outputJar();
+                    c.outputJdeps();
+                });
+        assertThat(String.join("\n", ctx.outLines())).contains("Loading modules");
+    }
+
+    @Test
+    public void testCompilerDiagnosticsAreReported() {
+        // Compiler diagnostics must be printed to stderr
+        ctx.runFailingCompileTaskAndValidateOutput(
+                () -> ctx.runCompileTask(
+                        c -> {
+                            c.useBuildToolsApi();
+                            c.compileKotlin();
+                            c.addSource(
+                                    "Broken.kt",
+                                    "package something;",
+                                    "",
+                                    "val broken = DoesNotExist()");
+                            c.outputJar();
+                            c.outputJdeps();
+                        }),
+                lines -> assertThat(String.join("\n", lines)).contains("DoesNotExist"));
     }
 }


### PR DESCRIPTION
- compiler errors and warnings were not printed to the stderr as they should
- run BTAPI compiler with '-verbose' flag if tracing is enabled