### PR TITLE
For BTAPI compiler ensure the code does not use JDK APIs newer than a…

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1039,7 +1039,12 @@ def _run_kt_java_builder_actions(
         kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options
         jvm_target = kotlinc_options.jvm_target if (kotlinc_options and kotlinc_options.jvm_target) else toolchains.kt.jvm_target
         if jvm_target:
-            javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target))
+            if toolchains.kt.experimental_build_tools_api:
+                # For BTA compiler, when linking against a platform different from the compiler's own JVM,
+                # use --release flag to ensure the JDK API version corresponds to selected jvmTarget.
+                javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target, toolchains.java.java_runtime.version))
+            else:
+                javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target))
 
         java_info = java_common.compile(
             ctx,

--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -47,14 +47,21 @@ def _init_builder_args(ctx, rule_kind, module_name, kotlinc_options = None):
 
     return args
 
-def _javac_jvm_target_flags(jvm_target):
-    """Derive javac `-source`/`-target` flags from a kotlinc `jvm_target`.
+def _javac_jvm_target_flags(jvm_target, compiler_version = None):
+    """Derive javac platform-target flags from a kotlinc `jvm_target`.
+
+    With `compiler_version` specified the compile-time API version is enforced with `["--release", N]` flag
+    when cross-compiling for older jvm versions.
+    else `-source`/`-target` are used (`--release` is mutually exclusive with them).
     """
     stripped = jvm_target.strip()
     dot = stripped.rfind(".")
     target_version = stripped if dot < 0 else stripped[dot + 1:]
     if not target_version.isdigit():
         fail("kotlinc jvm_target '{}' is not a valid JVM target version (expected a number like '8', '11', '17', or the legacy '1.8' form)".format(jvm_target))
+    if compiler_version != None:
+        if compiler_version >= 9 and compiler_version != int(target_version):
+            return ["--release", target_version]
     return ["-source", target_version, "-target", target_version]
 
 utils = struct(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -92,7 +92,14 @@ fun JvmCompilationTask.baseArgs(overrides: Map<String, String> = emptyMap()): Co
       LANGUAGE_VERSION_ARG,
       overrides[LANGUAGE_VERSION_ARG] ?: info.toolchainInfo.common.languageVersion,
     ).flag("-jvm-target", info.toolchainInfo.jvm.jvmTarget)
-    .flag("-module-name", info.moduleName)
+    .let { args ->
+      if (info.buildToolsApi && info.passthroughFlagsList.none { it.startsWith("-Xjdk-release") }) {
+        // Unless set explicitly, ensure the JDK API version corresponds to selected jvmTarget
+        args.flag("-Xjdk-release=${info.toolchainInfo.jvm.jvmTarget}")
+      } else {
+        args
+      }
+    }.flag("-module-name", info.moduleName)
 }
 
 internal fun JvmCompilationTask.plugins(

--- a/src/test/data/jvm/ksp/BUILD
+++ b/src/test/data/jvm/ksp/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_java//java:defs.bzl", "java_binary", "java_plugin")
-load("//kotlin:core.bzl", "kt_ksp_plugin")
+load("//kotlin:core.bzl", "kt_kotlinc_options", "kt_ksp_plugin")
 load("//kotlin:jvm.bzl", "kt_jvm_library")
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
@@ -17,6 +17,11 @@ load("//kotlin:jvm.bzl", "kt_jvm_library")
 # See the License for the specific language governing permissions and
 # limitations under the License.
 package(default_visibility = ["//visibility:private"])
+
+kt_kotlinc_options(
+    name = "jvm11_opts",
+    jvm_target = "11",
+)
 
 kt_ksp_plugin(
     name = "dagger",
@@ -90,6 +95,7 @@ kt_jvm_library(
         "coffee/PumpModule.kt",
         "coffee/Thermosiphon.kt",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [
         ":dagger",
         ":moshi",
@@ -142,6 +148,7 @@ kt_jvm_library(
         ":chai_lib_src",
         ":tea_lib_src",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [
         ":dagger",
         ":moshi",
@@ -163,6 +170,7 @@ kt_jvm_library(
         "coffee/CoffeeAppService.java",
         "coffee/CoffeeAppServiceUsage.kt",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [":autoservice"],
     deps = ["@kotlin_rules_maven//:dev_zacsweers_autoservice_auto_service_ksp"],
 )
@@ -184,6 +192,7 @@ kt_jvm_library(
         ":chai_lib_src",
         ":tea_lib_src",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [
         ":autoservice",
         ":autovalue",
@@ -230,6 +239,7 @@ kt_jvm_library(
         ":chai_lib_src",
         ":tea_lib_src",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [
         ":generate_bytecode_plugin",
         ":autovalue",
@@ -329,6 +339,7 @@ rm GeneratedModule.kt
 kt_jvm_library(
     name = "generated_lib",
     srcs = [":generated_module_src"],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [":dagger"],
     deps = ["@kotlin_rules_maven//:com_google_dagger_dagger"],
 )
@@ -342,6 +353,7 @@ kt_jvm_library(
         ":chai_lib_src",
         ":tea_lib_src",
     ],
+    kotlinc_opts = ":jvm11_opts",
     plugins = [
         ":dagger",
         ":moshi",

--- a/src/test/kotlin/io/bazel/generate/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/generate/BUILD.bazel
@@ -1,10 +1,17 @@
+load("//kotlin:core.bzl", "kt_kotlinc_options")
 load("//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_kotlinc_options(
+    name = "jvm11_opts",
+    jvm_target = "11",
+)
 
 kt_jvm_test(
     name = "WriteKotlincCapabilitiesTest",
     srcs = [
         "WriteKotlincCapabilitiesTest.kt",
     ],
+    kotlinc_opts = ":jvm11_opts",
     test_class = "io.bazel.generate.WriteKotlincCapabilitiesTest",
     deps = [
         "//src/main/kotlin/io/bazel/kotlin/generate:kotlin_release_options_lib",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
@@ -94,4 +94,21 @@ public class KotlinBuilderJvmBtaTest {
                         }),
                 lines -> assertThat(String.join("\n", lines)).contains("DoesNotExist"));
     }
+
+  @Test
+    public void testJdkApiSurfaceLimitedToJvmTarget() {
+        // The BTAPI implementation enforces compile-time JDK API version to correspond to the selected jvm_target via -Xjdk-release.
+        ctx.runFailingCompileTaskAndValidateOutput(
+                () -> ctx.runCompileTask(
+                        c -> {
+                            c.useBuildToolsApi();
+                            c.compileKotlin();
+                            // java.util.HexFormat exists since JDK 17, while the test toolchain targets jvm 11.
+                            c.addSource("HexUser.kt", "package something;", "fun hex(): String = java.util.HexFormat.of().toString()");
+                            c.outputJar();
+                            c.outputJdeps();
+                        }),
+                lines -> assertThat(String.join("\n", lines)).contains("HexFormat"));
+    }
+
 }

--- a/src/test/starlark/internal/jvm/javac_jvm_target_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_jvm_target_test.bzl
@@ -1,4 +1,4 @@
-"""Unit tests for `utils.javac_jvm_target_flags` (kotlinc jvm_target -> javac -source/-target flags)."""
+"""Unit tests for `utils.javac_jvm_target_flags` (kotlinc jvm_target -> javac platform flags)."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//kotlin/internal/utils:utils.bzl", "utils")
@@ -19,8 +19,30 @@ def _normalization_test_impl(ctx):
 
 normalization_test = unittest.make(_normalization_test_impl)
 
+def _release_selection_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # With a compiler version (Build Tools API path): a JDK 9+ compiler differing from the
+    # target -> genuine cross-compilation via --release.
+    asserts.equals(env, ["--release", "8"], utils.javac_jvm_target_flags("1.8", 17))
+    asserts.equals(env, ["--release", "8"], utils.javac_jvm_target_flags("8", 17))
+    asserts.equals(env, ["--release", "6"], utils.javac_jvm_target_flags("1.6", 21))
+    asserts.equals(env, ["--release", "17"], utils.javac_jvm_target_flags("17", 21))
+
+    # Compiler == target -> -source/-target (no cross-compilation).
+    asserts.equals(env, ["-source", "11", "-target", "11"], utils.javac_jvm_target_flags("11", 11))
+    asserts.equals(env, ["-source", "17", "-target", "17"], utils.javac_jvm_target_flags("17", 17))
+
+    # Pre-9 running compiler -> -source/-target even when the target differs.
+    asserts.equals(env, ["-source", "8", "-target", "8"], utils.javac_jvm_target_flags("1.8", 8))
+
+    return unittest.end(env)
+
+release_selection_test = unittest.make(_release_selection_test_impl)
+
 def javac_jvm_target_test_suite(name):
     unittest.suite(
         name,
         normalization_test,
+        release_selection_test,
     )


### PR DESCRIPTION
…vailable in configured jvm_target

When compiling via 'experimental_build_tools_api', both kotlin and java sources compile against the JDK API surface of the configured target JVM platform instead of the JDK used to run the compiler. The legacy (non-BTAPI) implementation is unchanged, so the stricter behavior arrives only with the explicit Build Tools API opt-in in the build configuration.

- For kotlin sources use `-Xjdk-release=<jvm_target>` flag matching the effective `-jvm-target`, unless the flag is set explicitly.
- For java sources use `--release N` flag if it is supported by the compiler and javac should link against the JVM older than the compiler's own JVM. Otherwise`-source N -target N` flags are used.
- To pass stricter build configuration, declare `jvm_target = "11"` on the test targets that are not actually Java 8 targets: their sources use JDK 9+/11+ APIs, or Dagger generates code using the newer APIs