### PR TITLE
Don't pass the transitive compile-jar closure to JdepsMerge

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -379,7 +379,7 @@ def _build_resourcejar_action(ctx, toolchains, extra_resources = {}):
     )
     return resources_jar_output
 
-def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jars = depset(), classpath_jars = None):
+def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, classpath_jars, associate_jars = depset()):
     """Creates a Jdeps merger action invocation."""
     args = ctx.actions.args()
     args.set_param_file_format("multiline")
@@ -403,20 +403,14 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jar
     if not toolchains.kt.experimental_report_unused_deps == "off":
         # For sandboxing to work, and for this action to be deterministic, the jars named in the merged jdeps need to
         # be passed as inputs. They can come from either the compile classpath or the direct dependency list.
-        if classpath_jars != None:
-            inputs = depset(
-                jdeps,
-                transitive = [
-                    classpath_jars,
-                    _java_infos_to_compile_jars(deps),
-                    associate_jars,
-                ],
-            )
-        else:
-            inputs = depset(
-                jdeps,
-                transitive = [dep.transitive_compile_time_jars for dep in deps] + [associate_jars],
-            )
+        inputs = depset(
+            jdeps,
+            transitive = [
+                classpath_jars,
+                _java_infos_to_compile_jars(deps),
+                associate_jars,
+            ],
+        )
 
     ctx.actions.run(
         mnemonic = mnemonic,
@@ -1068,8 +1062,7 @@ def _run_kt_java_builder_actions(
     # If there is Java source or KAPT/KSP generated Java source compile that Java and fold it into
     # the final ABI jar. Otherwise just use the KT ABI jar as final ABI jar.
     ksp_generated_java_src_jars = generated_ksp_src_jars and is_ksp_processor_generating_java(ctx.attr.plugins)
-    compiles_java = bool(srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars)
-    if compiles_java:
+    if srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars:
         javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
         javac_opts = javac_options_to_flags(javac_options)
         javac_opts.extend([
@@ -1156,9 +1149,7 @@ def _run_kt_java_builder_actions(
                 deps = compile_deps.deps,
                 associate_jars = compile_deps.associate_jars,
                 outputs = {"output": output_jdeps},
-                # javac compiles against the unpruned transitive classpath, so its jdeps can name
-                # jars outside the Kotlin compile classpath.
-                classpath_jars = None if compiles_java else compile_deps.compile_jars,
+                classpath_jars = compile_deps.compile_jars,
             )
         else:
             ctx.actions.symlink(

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -401,11 +401,17 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jar
 
     inputs = depset(jdeps)
     if not toolchains.kt.experimental_report_unused_deps == "off":
-        # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs.
-        # The merger only opens the jars named in the merged jdeps, and those can only come from the compile classpath,
-        # so callers that know the classpath pass it instead of the whole transitive closure.
+        # For sandboxing to work, and for this action to be deterministic, the jars named in the merged jdeps need to
+        # be passed as inputs. They can come from either the compile classpath or the direct dependency list.
         if classpath_jars != None:
-            inputs = depset(jdeps, transitive = [classpath_jars])
+            inputs = depset(
+                jdeps,
+                transitive = [
+                    classpath_jars,
+                    _java_infos_to_compile_jars(deps),
+                    associate_jars,
+                ],
+            )
         else:
             inputs = depset(
                 jdeps,

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -379,7 +379,7 @@ def _build_resourcejar_action(ctx, toolchains, extra_resources = {}):
     )
     return resources_jar_output
 
-def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jars = depset()):
+def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jars = depset(), classpath_jars = None):
     """Creates a Jdeps merger action invocation."""
     args = ctx.actions.args()
     args.set_param_file_format("multiline")
@@ -402,13 +402,15 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jar
     inputs = depset(jdeps)
     if not toolchains.kt.experimental_report_unused_deps == "off":
         # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs.
-        # The associate jars are included as well because the merger reads the owning label out of the manifest of every
-        # jar mentioned in the jdeps, and the jar the associate contributed to the classpath is not necessarily its
-        # compile jar, see associates.bzl.
-        inputs = depset(
-            jdeps,
-            transitive = [dep.transitive_compile_time_jars for dep in deps] + [associate_jars],
-        )
+        # The merger only opens the jars named in the merged jdeps, and those can only come from the compile classpath,
+        # so callers that know the classpath pass it instead of the whole transitive closure.
+        if classpath_jars != None:
+            inputs = depset(jdeps, transitive = [classpath_jars])
+        else:
+            inputs = depset(
+                jdeps,
+                transitive = [dep.transitive_compile_time_jars for dep in deps] + [associate_jars],
+            )
 
     ctx.actions.run(
         mnemonic = mnemonic,
@@ -1060,7 +1062,8 @@ def _run_kt_java_builder_actions(
     # If there is Java source or KAPT/KSP generated Java source compile that Java and fold it into
     # the final ABI jar. Otherwise just use the KT ABI jar as final ABI jar.
     ksp_generated_java_src_jars = generated_ksp_src_jars and is_ksp_processor_generating_java(ctx.attr.plugins)
-    if srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars:
+    compiles_java = bool(srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars)
+    if compiles_java:
         javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
         javac_opts = javac_options_to_flags(javac_options)
         javac_opts.extend([
@@ -1147,6 +1150,9 @@ def _run_kt_java_builder_actions(
                 deps = compile_deps.deps,
                 associate_jars = compile_deps.associate_jars,
                 outputs = {"output": output_jdeps},
+                # javac compiles against the unpruned transitive classpath, so its jdeps can name
+                # jars outside the Kotlin compile classpath.
+                classpath_jars = None if compiles_java else compile_deps.compile_jars,
             )
         else:
             ctx.actions.symlink(

--- a/src/test/starlark/rules/BUILD.bazel
+++ b/src/test/starlark/rules/BUILD.bazel
@@ -2,6 +2,7 @@ load("//kotlin:core.bzl", "define_kt_toolchain")
 load(":associates_tests.bzl", "associates_tests")
 load(":build_tools_api_toggle_tests.bzl", "build_tools_api_toggle_tests")
 load(":experimental_prune_transitive_deps_tests.bzl", "experimental_prune_transitive_deps_tests")
+load(":jdeps_merge_inputs_tests.bzl", "jdeps_merge_inputs_tests")
 
 build_tools_api_toggle_tests(
     name = "build_tools_api_toggle_tests",
@@ -32,4 +33,14 @@ define_kt_toolchain(
     experimental_strict_kotlin_deps = "error",
     experimental_treat_internal_as_private_in_abi_jars = True,
     experimental_use_abi_jars = True,
+)
+
+jdeps_merge_inputs_tests(
+    name = "jdeps_merge_inputs_tests",
+)
+
+# Only registered through --extra_toolchains by the tests that need unused dep reporting on.
+define_kt_toolchain(
+    name = "report_unused_deps_toolchain",
+    experimental_report_unused_deps = "warn",
 )

--- a/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
+++ b/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
@@ -1,0 +1,115 @@
+"""Tests for the inputs declared on the JdepsMerge action."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:truth.bzl", "matching")
+load("//src/test/starlark:case.bzl", "suite")
+load(":arrangement.bzl", "arrange")
+load(":util.bzl", "abi_jar_of")
+
+_REPORT_UNUSED_DEPS_TOOLCHAIN = str(Label("@rules_kotlin//src/test/starlark/rules:report_unused_deps_toolchain"))
+
+_ATTRS = {
+    "not_want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+    "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+}
+
+def _jdeps_merge_input_assertions(env, target):
+    action = env.expect.that_target(target).action_named("JdepsMerge")
+
+    # Compare by basename: with config_settings the target is analyzed in a transitioned
+    # configuration, so the output path prefix differs.
+    action.inputs().contains_at_least_predicates([
+        matching.file_basename_equals(abi_jar_of(f.basename))
+        for f in env.ctx.files.want_inputs
+        if not f.basename.endswith("jdeps")
+    ])
+    for f in env.ctx.files.not_want_inputs:
+        if f.basename.endswith("jdeps"):
+            continue
+        action.inputs().not_contains_predicate(matching.file_basename_equals(abi_jar_of(f.basename)))
+
+def _config_settings(report_unused_deps):
+    settings = {
+        str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+        str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [],
+        str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+    }
+    if report_unused_deps:
+        settings["//command_line_option:extra_toolchains"] = [_REPORT_UNUSED_DEPS_TOOLCHAIN]
+    return settings
+
+def _test_kotlin_only_target_gets_the_compile_classpath(test):
+    """A Kotlin only target only needs the jars that can appear in its jdeps.
+
+    Those are the jars on the Kotlin compile classpath, which with
+    experimental_prune_transitive_deps is a strict subset of the transitive closure.
+    """
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(test)
+
+    analysis_test(
+        name = test.name,
+        impl = _jdeps_merge_input_assertions,
+        target = main_target_library,
+        config_settings = _config_settings(report_unused_deps = True),
+        attr_values = {
+            "not_want_inputs": [
+                dependency_a_trans_dep_jar,
+            ],
+            "want_inputs": [
+                dependency_a,
+            ],
+        },
+        attrs = _ATTRS,
+    )
+
+def _test_target_with_java_sources_gets_the_transitive_closure(test):
+    """javac compiles against the unpruned transitive classpath.
+
+    Its jdeps can therefore name jars that are not on the Kotlin compile classpath, so the
+    transitive closure has to stay declared for targets that also run javac.
+    """
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(
+        test,
+        with_java_main = True,
+    )
+
+    analysis_test(
+        name = test.name,
+        impl = _jdeps_merge_input_assertions,
+        target = main_target_library,
+        config_settings = _config_settings(report_unused_deps = True),
+        attr_values = {
+            "not_want_inputs": [],
+            "want_inputs": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+        },
+        attrs = _ATTRS,
+    )
+
+def _test_report_unused_deps_off_gets_no_jars(test):
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(test)
+
+    analysis_test(
+        name = test.name,
+        impl = _jdeps_merge_input_assertions,
+        target = main_target_library,
+        config_settings = _config_settings(report_unused_deps = False),
+        attr_values = {
+            "not_want_inputs": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+            "want_inputs": [],
+        },
+        attrs = _ATTRS,
+    )
+
+def jdeps_merge_inputs_tests(name):
+    suite(
+        name,
+        kotlin_only = _test_kotlin_only_target_gets_the_compile_classpath,
+        with_java_sources = _test_target_with_java_sources_gets_the_transitive_closure,
+        report_unused_deps_off = _test_report_unused_deps_off_gets_no_jars,
+    )

--- a/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
+++ b/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
@@ -28,9 +28,9 @@ def _jdeps_merge_input_assertions(env, target):
             continue
         action.inputs().not_contains_predicate(matching.file_basename_equals(abi_jar_of(f.basename)))
 
-def _config_settings(report_unused_deps):
+def _config_settings(report_unused_deps, prune_transitive_deps = True):
     settings = {
-        str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+        str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): prune_transitive_deps,
         str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [],
         str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
     }
@@ -103,10 +103,36 @@ def _test_report_unused_deps_off_gets_no_jars(test):
         attrs = _ATTRS,
     )
 
+def _test_mixed_target_without_pruning_gets_transitive_classpath(test):
+    """A mixed Kotlin/Java target keeps transitive jars when pruning is disabled."""
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(
+        test,
+        with_java_main = True,
+    )
+
+    analysis_test(
+        name = test.name,
+        impl = _jdeps_merge_input_assertions,
+        target = main_target_library,
+        config_settings = _config_settings(
+            report_unused_deps = True,
+            prune_transitive_deps = False,
+        ),
+        attr_values = {
+            "not_want_inputs": [],
+            "want_inputs": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+        },
+        attrs = _ATTRS,
+    )
+
 def jdeps_merge_inputs_tests(name):
     suite(
         name,
         kotlin_only = _test_kotlin_only_target_gets_the_compile_classpath,
         with_java_sources = _test_target_with_java_sources_gets_the_compile_classpath,
         report_unused_deps_off = _test_report_unused_deps_off_gets_no_jars,
+        pruning_disabled = _test_mixed_target_without_pruning_gets_transitive_classpath,
     )

--- a/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
+++ b/src/test/starlark/rules/jdeps_merge_inputs_tests.bzl
@@ -62,12 +62,8 @@ def _test_kotlin_only_target_gets_the_compile_classpath(test):
         attrs = _ATTRS,
     )
 
-def _test_target_with_java_sources_gets_the_transitive_closure(test):
-    """javac compiles against the unpruned transitive classpath.
-
-    Its jdeps can therefore name jars that are not on the Kotlin compile classpath, so the
-    transitive closure has to stay declared for targets that also run javac.
-    """
+def _test_target_with_java_sources_gets_the_compile_classpath(test):
+    """A mixed Kotlin/Java target gets the pruned Kotlin compile classpath for JdepsMerge."""
     (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(
         test,
         with_java_main = True,
@@ -79,10 +75,11 @@ def _test_target_with_java_sources_gets_the_transitive_closure(test):
         target = main_target_library,
         config_settings = _config_settings(report_unused_deps = True),
         attr_values = {
-            "not_want_inputs": [],
+            "not_want_inputs": [
+                dependency_a_trans_dep_jar,
+            ],
             "want_inputs": [
                 dependency_a,
-                dependency_a_trans_dep_jar,
             ],
         },
         attrs = _ATTRS,
@@ -110,6 +107,6 @@ def jdeps_merge_inputs_tests(name):
     suite(
         name,
         kotlin_only = _test_kotlin_only_target_gets_the_compile_classpath,
-        with_java_sources = _test_target_with_java_sources_gets_the_transitive_closure,
+        with_java_sources = _test_target_with_java_sources_gets_the_compile_classpath,
         report_unused_deps_off = _test_report_unused_deps_off_gets_no_jars,
     )


### PR DESCRIPTION
## What this changes

`_run_merge_jdeps_action` declares the **full transitive compile-jar closure** of every dependency as
inputs to the `JdepsMerge` action whenever `experimental_report_unused_deps != "off"`. The merger only
opens the jars that the merged jdeps actually names, and those can only be jars that were on the Kotlin
compile classpath, so the closure is over-declared. This PR adds an optional `classpath_jars` argument and
passes `compile_deps.compile_jars` for Kotlin-only targets; targets that also run javac keep the old input
set, because javac compiles against the unpruned transitive classpath and its jdeps can name jars outside
the Kotlin classpath.

The win only materialises when `experimental_prune_transitive_deps` is on — otherwise the compile classpath
*is* the transitive closure and the input set is unchanged.

### Why it is safe

- `BaseJdepsGenExtension.doWriteJdeps` emits exactly two kinds of paths: the entries of
  `--direct_dependencies` (as `UNUSED`) and the jars classes were loaded from, both mapped through
  `--full_classpath`. `_run_kt_builder_action` sets `--direct_dependencies` from the direct deps' compile
  jars and `--classpath` from `compile_deps.compile_jars`; the former is a subset of the latter.
- `JdepsMerger.merge` reads `Target-Label` from the manifest of exactly the paths present in the merged
  jdeps. So every jar it opens is in `compile_deps.compile_jars`.
- If that reasoning were ever wrong, the action fails with a missing-input error — it cannot silently
  mis-report unused deps.

### Tests

`src/test/starlark/rules/jdeps_merge_inputs_tests.bzl` asserts the `JdepsMerge` input set with
`experimental_prune_transitive_deps` on, against a `main -> dependency_a -> transitive_dep` graph:

- `kotlin_only` — with unused-dep reporting on, inputs contain `dependency_a`'s compile jar but not the
  transitive one (fails without this change).
- `with_java_sources` — the same target with an added `.java` source still gets the transitive closure.
- `report_unused_deps_off` — no dep jars are declared at all.

Reporting is enabled by pointing `--extra_toolchains` at a toolchain declared in the test package, since
`experimental_report_unused_deps` is a toolchain attribute rather than a flag.

I also verified end to end in a scratch package with `experimental_report_unused_deps = "error"` and
`experimental_prune_transitive_deps = True` that an unused direct dep on a Kotlin-only `kt_jvm_library`
still fails the build with `** Please remove the following dependencies:`, that a target whose deps are all
used builds clean, and that both hold for a mixed Kotlin/Java target.

## Measurements

From a ~1,500 `kt_library` target Kotlin monorepo with pruning enabled.

Static input counts, `bazel aquery 'mnemonic("JdepsMerge", deps(<target>))'`:

| Subgraph | JdepsMerge actions | inputs before | inputs after | mean/action |
| --- | --- | --- | --- | --- |
| graphqlapi | 631 | 90,165 | 12,659 (−86%) | 142.9 → 20.1 |
| socialapi | 263 | 13,125 | 3,746 (−71%) | 49.9 → 14.2 |

Invalidation fan-in (for each first-party jar, how many JdepsMerge actions it invalidates when its ABI
changes): graphqlapi mean 58.2 → 8.5, socialapi 12.4 → 4.1. These targets do not recompile on such a
change (pruned classpath), only their merge action was being invalidated.

Cold remote-execution A/B on one subgraph (95 JdepsMerge executions in both arms): worker-fetched bytes
144.3 MB → 53.6 MB (−63%), files 454 → 289; per-action exec time unchanged (~0.25 s). The win is fetched
bytes, merkle-tree/digest work, cache-lookup payload and invalidation — not per-action CPU.
