### PR TITLE
Fix resource_strip_prefix labels naming a directory nested in the pac…

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -300,16 +300,23 @@ def _resourcejar_args_action(ctx, extra_resources = {}):
             # Strip prefix root mismatch
             file_path = file_path[len(file.root.path):]
 
-        # if dirname starts with ctx.label.package, we need to remove ctx.label.package, because it means that
-        # we've hit the edge case when there is a target with the same name as the package
-        if file.dirname.startswith(ctx.label.package + "/"):
-            strip_prefix = file_path[len(ctx.label.package) + 1:]
-        else:
-            strip_prefix = file_path
+        # The attribute can be specified either as a workspace-root-relative path (the
+        # rules_java convention) or as a label to a directory inside the package. Both parse as a
+        # package-relative label, so the first candidate will be either in "pkg/pkg/path" form,
+        # or in "pkg/path" form.
+        candidates = [file_path]
+        if file_path.startswith(ctx.label.package + "/"):
+            candidates.append(file_path[len(ctx.label.package) + 1:])
 
         if ctx.files.resources and file.root.path != ctx.files.resources[0].root.path:
-            # Add back the root path to align with resources paths
-            strip_prefix = ctx.files.resources[0].root.path + "/" + strip_prefix
+            # Align the candidates with the resources' root.
+            candidates = [ctx.files.resources[0].root.path + "/" + c for c in candidates]
+
+        strip_prefix = candidates[0]
+        for candidate in candidates:
+            if ctx.files.resources and ctx.files.resources[0].path.startswith(candidate):
+                strip_prefix = candidate
+                break
 
     for f in ctx.files.resources:
         resource_path = f.path if strip_prefix else _resource_path_relative_to_root(f)

--- a/src/test/starlark/internal/jvm/resource_strip_prefix_test.bzl
+++ b/src/test/starlark/internal/jvm/resource_strip_prefix_test.bzl
@@ -87,10 +87,73 @@ def _strip_resource_prefix_contents():
     )
 
     kt_jvm_library(
+        name = "workspace_relative_dynamically_created_file",
+        srcs = ["source"],
+        resource_strip_prefix = pkg + "/resourcez",
+        resources = ["file"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
         name = "static_file",
         srcs = ["source"],
         resource_strip_prefix = "test_resources",
         resources = ["test_resources/resource.txt"],  # static file in the package
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "workspace_relative_static_file",
+        srcs = ["source"],
+        resource_strip_prefix = pkg + "/test_resources",
+        resources = ["test_resources/resource.txt"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "nested_static_dir",
+        srcs = ["source"],
+        resource_strip_prefix = "test_resources/nested",
+        resources = ["test_resources/nested/nested_resource.txt"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "workspace_relative_nested_dir",
+        srcs = ["source"],
+        # The rules_java-style spelling: the full workspace-root-relative path, which parses as a
+        # package-relative label and resolves to a doubled <pkg>/<pkg>/... path.
+        resource_strip_prefix = pkg + "/test_resources/nested",
+        resources = ["test_resources/nested/nested_resource.txt"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "package_root_dir",
+        srcs = ["source"],
+        # The workspace-root-relative spelling of the package itself: strips the entire package,
+        # leaving the in-package path as the jar entry. This scenario has no package-relative
+        # sibling: a package-relative label cannot name the package directory itself.
+        resource_strip_prefix = pkg,
+        resources = ["test_resources/resource.txt"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "package_name_collision_dir",
+        srcs = ["source"],
+        # An ordinary package-relative path to an in-package directory that only coincidentally
+        # spells like the package itself (the same resolved value as package_root_dir's attribute)
+        resource_strip_prefix = "src/test/starlark",
+        resources = ["src/test/starlark/collision_resource.txt"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "workspace_relative_collision_dir",
+        srcs = ["source"],
+        resource_strip_prefix = pkg + "/src/test/starlark",
+        resources = ["src/test/starlark/collision_resource.txt"],
         tags = ["manual"],
     )
 
@@ -129,9 +192,25 @@ def _strip_resource_prefix_contents():
         tags = ["manual"],
     )
 
+    kt_jvm_library(
+        name = "workspace_relative_same_as_package_name",
+        srcs = ["source"],
+        resources = [package_name],  # filegroup defined above
+        resource_strip_prefix = pkg + "/test_resources",
+        tags = ["manual"],
+    )
+
     resource_path_test(
         name = "dynamically_created_file_test",
         target_under_test = ":dynamically_created_file",
+        tags = ["manual"],
+        expected_destination_path = "resource.txt",
+        expected_source_suffix = pkg + "/resourcez/resource.txt",
+    )
+
+    resource_path_test(
+        name = "workspace_relative_dynamically_created_file_test",
+        target_under_test = ":workspace_relative_dynamically_created_file",
         tags = ["manual"],
         expected_destination_path = "resource.txt",
         expected_source_suffix = pkg + "/resourcez/resource.txt",
@@ -143,6 +222,54 @@ def _strip_resource_prefix_contents():
         tags = ["manual"],
         expected_destination_path = "resource.txt",
         expected_source_suffix = pkg + "/test_resources/resource.txt",
+    )
+
+    resource_path_test(
+        name = "workspace_relative_static_file_test",
+        target_under_test = ":workspace_relative_static_file",
+        tags = ["manual"],
+        expected_destination_path = "resource.txt",
+        expected_source_suffix = pkg + "/test_resources/resource.txt",
+    )
+
+    resource_path_test(
+        name = "nested_static_dir_test",
+        target_under_test = ":nested_static_dir",
+        tags = ["manual"],
+        expected_destination_path = "nested_resource.txt",
+        expected_source_suffix = pkg + "/test_resources/nested/nested_resource.txt",
+    )
+
+    resource_path_test(
+        name = "workspace_relative_nested_dir_test",
+        target_under_test = ":workspace_relative_nested_dir",
+        tags = ["manual"],
+        expected_destination_path = "nested_resource.txt",
+        expected_source_suffix = pkg + "/test_resources/nested/nested_resource.txt",
+    )
+
+    resource_path_test(
+        name = "package_root_dir_test",
+        target_under_test = ":package_root_dir",
+        tags = ["manual"],
+        expected_destination_path = "test_resources/resource.txt",
+        expected_source_suffix = pkg + "/test_resources/resource.txt",
+    )
+
+    resource_path_test(
+        name = "package_name_collision_dir_test",
+        target_under_test = ":package_name_collision_dir",
+        tags = ["manual"],
+        expected_destination_path = "collision_resource.txt",
+        expected_source_suffix = pkg + "/src/test/starlark/collision_resource.txt",
+    )
+
+    resource_path_test(
+        name = "workspace_relative_collision_dir_test",
+        target_under_test = ":workspace_relative_collision_dir",
+        tags = ["manual"],
+        expected_destination_path = "collision_resource.txt",
+        expected_source_suffix = pkg + "/src/test/starlark/collision_resource.txt",
     )
 
     resource_path_test(
@@ -177,6 +304,14 @@ def _strip_resource_prefix_contents():
         expected_source_suffix = pkg + "/test_resources/actual_file.txt",
     )
 
+    resource_path_test(
+        name = "workspace_relative_same_as_package_name_test",
+        target_under_test = ":workspace_relative_same_as_package_name",
+        tags = ["manual"],
+        expected_destination_path = "actual_file.txt",
+        expected_source_suffix = pkg + "/test_resources/actual_file.txt",
+    )
+
 # Entry point from the BUILD file; macro for running each test case's macro and
 # declaring a test suite that wraps them together.
 def strip_resource_prefix_test_suite(name):
@@ -187,6 +322,14 @@ def strip_resource_prefix_test_suite(name):
         name = name,
         tests = [
             ":dynamically_created_file_test",
+            ":nested_static_dir_test",
+            ":package_name_collision_dir_test",
+            ":package_root_dir_test",
+            ":workspace_relative_collision_dir_test",
+            ":workspace_relative_dynamically_created_file_test",
+            ":workspace_relative_nested_dir_test",
+            ":workspace_relative_same_as_package_name_test",
+            ":workspace_relative_static_file_test",
             ":generated_default_package_test",
             ":generated_standard_package_test",
             ":static_file_test",

--- a/src/test/starlark/src/test/starlark/collision_resource.txt
+++ b/src/test/starlark/src/test/starlark/collision_resource.txt
@@ -1,0 +1,1 @@
+package-name collision fixture

--- a/src/test/starlark/test_resources/nested/nested_resource.txt
+++ b/src/test/starlark/test_resources/nested/nested_resource.txt
@@ -1,0 +1,1 @@
+nested resource fixture


### PR DESCRIPTION
…kage

Strip prefixes naming a nested directory (like "src/main/resources") failed analysis with "Resource file ... is not under the specified prefix to strip".

Every strip prefix is parsed as a label. Although the resolved string had the correct "pkg/path" form, the "pkg/" part was stripped by the logic added to compensate for the legacy workspace-root-relative spelling of the strip prefix.

The fix computes both workspace-root-relative and package-relative candidate prefixes and keeps the one the packed resources actually live under.

Added tests to cover every scenario in both spellings, including layouts where the nested in-package path is by coincidence equal to the package path from the workspace root.