### PR TITLE
Remove dagger from src/main/kotlin/shade.jarjar

### DIFF
--- a/src/main/kotlin/shade.jarjar
+++ b/src/main/kotlin/shade.jarjar
@@ -1,3 +1,2 @@
-rule dagger.** io.bazel.kotlin.builder.dagger.@1
 rule com.google.common.** io.bazel.kotlin.builder.guava.@1
 zap kotlin.**


### PR DESCRIPTION
Dagger isn't being used in the builder anymore, so there is nothing to jarjar/shade.