### PR TITLE
Forward runtime_deps on a sourceless kt_jvm_library

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1197,6 +1197,7 @@ def _export_only_providers(ctx, actions, attr, outputs):
         compile_jar = toolchains.kt.empty_jar,
         deps = [_java_info(d) for d in attr.deps],
         exports = [_java_info(d) for d in getattr(attr, "exports", [])],
+        runtime_deps = [_java_info(d) for d in getattr(attr, "runtime_deps", [])],
         neverlink = getattr(attr, "neverlink", False),
         jdeps = output_jdeps,
     )

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -2,6 +2,7 @@ load(":export_only_module_name_test.bzl", "export_only_module_name_test_suite")
 load(":javac_jvm_target_test.bzl", "javac_jvm_target_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
+load(":sourceless_library_test.bzl", "sourceless_library_test_suite")
 
 export_only_module_name_test_suite(name = "export_only_module_name_tests")
 
@@ -10,3 +11,5 @@ javac_jvm_target_test_suite(name = "javac_jvm_target_tests")
 jvm_deps_test_suite(name = "jvm_tests")
 
 kt_jvm_binary_env_test_suite(name = "kt_jvm_binary_env_tests")
+
+sourceless_library_test_suite(name = "sourceless_library_tests")

--- a/src/test/starlark/internal/jvm/sourceless_library_test.bzl
+++ b/src/test/starlark/internal/jvm/sourceless_library_test.bzl
@@ -1,0 +1,71 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_java//java:defs.bzl", "JavaInfo")
+load("//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
+
+def _sourceless_library_runtime_deps_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    # The runtime dep must flow to the sourceless library's transitive runtime classpath, exactly
+    # as it does for a compiled library.
+    runtime_jars = [jar.basename for jar in target[JavaInfo].transitive_runtime_jars.to_list()]
+    asserts.true(
+        env,
+        "sourceless_library_dep.jar" in runtime_jars,
+        msg = "expected the runtime dep jar on the transitive runtime classpath, got %s" % runtime_jars,
+    )
+
+    # A runtime dep grants no compile-time visibility of any kind.
+    compile_jars = [jar.basename for jar in target[JavaInfo].compile_jars.to_list()]
+    asserts.false(
+        env,
+        "sourceless_library_dep.jar" in compile_jars,
+        msg = "the runtime dep jar must not be exported as a direct compile jar: %s" % compile_jars,
+    )
+
+    transitive_compile_jars = [jar.basename for jar in target[JavaInfo].transitive_compile_time_jars.to_list()]
+    asserts.false(
+        env,
+        "sourceless_library_dep.jar" in transitive_compile_jars,
+        msg = "the runtime dep jar must not be on the transitive compile-time classpath: %s" % transitive_compile_jars,
+    )
+
+    return analysistest.end(env)
+
+_sourceless_library_runtime_deps_test = analysistest.make(_sourceless_library_runtime_deps_test_impl)
+
+def _sourceless_library_contents():
+    write_file(
+        name = "sourceless_library_dep_jar",
+        out = "sourceless_library_dep.jar",
+        tags = ["manual"],
+    )
+
+    kt_jvm_import(
+        name = "sourceless_library_dep",
+        jars = ["sourceless_library_dep.jar"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "sourceless_library",
+        srcs = [],
+        runtime_deps = [":sourceless_library_dep"],
+        tags = ["manual"],
+    )
+
+    _sourceless_library_runtime_deps_test(
+        name = "sourceless_library_forwards_runtime_deps_test",
+        target_under_test = ":sourceless_library",
+    )
+
+def sourceless_library_test_suite(name):
+    _sourceless_library_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":sourceless_library_forwards_runtime_deps_test",
+        ],
+    )


### PR DESCRIPTION
- A kt_jvm_library without srcs produced JavaInfo which omitted runtime_deps entirely.
- Tests added.