### PR TITLE
Extend experimental_prune_transitive_deps semantics to the javac half…

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1075,7 +1075,7 @@ def _run_kt_java_builder_actions(
             source_files = srcs.java,
             source_jars = generated_kapt_src_jars + srcs.src_jars + (generated_ksp_src_jars if ksp_generated_java_src_jars else []),
             output = ctx.actions.declare_file(ctx.label.name + "-java.jar"),
-            deps = compile_deps.deps + kt_stubs_for_java + [p[JavaInfo] for p in ctx.attr.plugins if JavaInfo in p],
+            deps = compile_deps.java_deps + kt_stubs_for_java + [p[JavaInfo] for p in ctx.attr.plugins if JavaInfo in p],
             java_toolchain = toolchains.java,
             plugins = _plugin_mappers.targets_to_annotation_processors_java_plugin_info(ctx.attr.plugins),
             javac_opts = javac_opts,

--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -35,9 +35,11 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
         [toolchains.kt.jvm_stdlibs]
     )
 
+    prune_transitive_deps = (toolchains.kt.experimental_prune_transitive_deps and
+                             not "kt_experimental_prune_transitive_deps_incompatible" in ctx.attr.tags)
+
     # Reduced classpath, exclude transitive deps from compilation
-    if (toolchains.kt.experimental_prune_transitive_deps and
-        not "kt_experimental_prune_transitive_deps_incompatible" in ctx.attr.tags):
+    if prune_transitive_deps:
         transitive_jars = []
         repositories_to_keep = toolchains.kt.experimental_prune_transitive_deps_keep_transitive_repositories
         if repositories_to_keep:
@@ -73,9 +75,19 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
     ).to_list()
     compile_depset_list_filtered = [jar for jar in compile_depset_list if not _sets.contains(associates.abi_jar_set, jar)]
 
+    # The deps the Java half compiles against
+    if prune_transitive_deps:
+        java_deps = [
+            JavaInfo(output_jar = jar, compile_jar = jar, deps = [], neverlink = True)
+            for jar in compile_depset_list_filtered
+        ]
+    else:
+        java_deps = dep_infos
+
     return struct(
         module_name = associates.module_name,
         deps = dep_infos,
+        java_deps = java_deps,
         exports = [_java_info(d) for d in exports],
         associate_jars = associates.jars,
         compile_jars = depset(direct = compile_depset_list_filtered),

--- a/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
+++ b/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
@@ -524,6 +524,135 @@ def _sourceless_dep_propagation_test(name):
         target = name + "_subject",
     )
 
+def _pruned_java_deps_are_neverlink_test_impl(env, target):
+    direct_dep_java_info = JavaInfo(
+        compile_jar = _file(env.ctx.attr.direct_dep_abi_jar),
+        output_jar = _file(env.ctx.attr.direct_dep_abi_jar),
+    )
+
+    direct_deps = [{JavaInfo: direct_dep_java_info}]
+
+    fake_ctx = struct(
+        label = target.label,
+        attr = struct(
+            module_name = "",
+            tags = [],
+        ),
+    )
+
+    toolchains = struct(
+        kt = struct(
+            experimental_remove_private_classes_in_abi_jars = False,
+            experimental_prune_transitive_deps = True,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
+            experimental_strict_associate_dependencies = False,
+            jvm_stdlibs = JavaInfo(
+                compile_jar = _file(env.ctx.attr.jvm_jar),
+                output_jar = _file(env.ctx.attr.jvm_jar),
+            ),
+        ),
+    )
+
+    result = _jvm_deps_utils.jvm_deps(
+        ctx = fake_ctx,
+        toolchains = toolchains,
+        associate_deps = [],
+        deps = direct_deps,
+    )
+
+    # The synthetic Java-half deps must mirror the pruned compile classpath ...
+    pruned_compile_jars = []
+    for java_info in result.java_deps:
+        pruned_compile_jars.extend([f.short_path for f in java_info.compile_jars.to_list()])
+    expected_compile_jars = [f.short_path for f in result.compile_jars.to_list()]
+    env.expect.that_collection(sorted(pruned_compile_jars)).contains_exactly(sorted(expected_compile_jars))
+
+    # ... and be neverlink: their stripped, body-less ABI jars must NOT leak onto the runtime
+    # classpath. A neverlink JavaInfo contributes no transitive_runtime_jars.
+    leaked_runtime_jars = []
+    for java_info in result.java_deps:
+        leaked_runtime_jars.extend([f.basename for f in java_info.transitive_runtime_jars.to_list()])
+    env.expect.that_bool(len(leaked_runtime_jars) == 0).equals(True)
+
+def _pruned_java_deps_are_neverlink_test(name):
+    util.helper_target(
+        native.filegroup,
+        name = name + "_subject",
+        srcs = [],
+    )
+    analysis_test(
+        name = name,
+        impl = _pruned_java_deps_are_neverlink_test_impl,
+        target = name + "_subject",
+        attr_values = {
+            "direct_dep_abi_jar": util.empty_file(name + "direct_dep_abi.jar"),
+            "jvm_jar": util.empty_file(name + "jvm.jar"),
+        },
+        attrs = {
+            "direct_dep_abi_jar": attr.label(allow_files = True),
+            "jvm_jar": attr.label(allow_files = True),
+        },
+    )
+
+def _java_deps_follow_deps_without_pruning_test_impl(env, target):
+    direct_dep_java_info = JavaInfo(
+        compile_jar = _file(env.ctx.attr.direct_dep_abi_jar),
+        output_jar = _file(env.ctx.attr.direct_dep_abi_jar),
+    )
+
+    direct_deps = [{JavaInfo: direct_dep_java_info}]
+
+    fake_ctx = struct(
+        label = target.label,
+        attr = struct(
+            module_name = "",
+            tags = [],
+        ),
+    )
+
+    toolchains = struct(
+        kt = struct(
+            experimental_remove_private_classes_in_abi_jars = False,
+            experimental_prune_transitive_deps = False,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
+            experimental_strict_associate_dependencies = False,
+            jvm_stdlibs = JavaInfo(
+                compile_jar = _file(env.ctx.attr.jvm_jar),
+                output_jar = _file(env.ctx.attr.jvm_jar),
+            ),
+        ),
+    )
+
+    result = _jvm_deps_utils.jvm_deps(
+        ctx = fake_ctx,
+        toolchains = toolchains,
+        associate_deps = [],
+        deps = direct_deps,
+    )
+
+    # Without pruning, the Java half compiles against exactly the regular deps.
+    env.expect.that_bool(result.java_deps == result.deps).equals(True)
+
+def _java_deps_follow_deps_without_pruning_test(name):
+    util.helper_target(
+        native.filegroup,
+        name = name + "_subject",
+        srcs = [],
+    )
+    analysis_test(
+        name = name,
+        impl = _java_deps_follow_deps_without_pruning_test_impl,
+        target = name + "_subject",
+        attr_values = {
+            "direct_dep_abi_jar": util.empty_file(name + "direct_dep_abi.jar"),
+            "jvm_jar": util.empty_file(name + "jvm.jar"),
+        },
+        attrs = {
+            "direct_dep_abi_jar": attr.label(allow_files = True),
+            "jvm_jar": attr.label(allow_files = True),
+        },
+    )
+
 def jvm_deps_test_suite(name):
     test_suite(
         name,
@@ -534,6 +663,8 @@ def jvm_deps_test_suite(name):
             _transitive_from_associates_test,
             _dep_infos_ordering_test,
             _kept_transitive_repository_deduplication_test,
+            _pruned_java_deps_are_neverlink_test,
+            _java_deps_follow_deps_without_pruning_test,
             _sourceless_dep_propagation_test,
         ],
     )

--- a/src/test/starlark/rules/arrangement.bzl
+++ b/src/test/starlark/rules/arrangement.bzl
@@ -1,6 +1,6 @@
 load("//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
 
-def arrange(test, transitive_dep = None):
+def arrange(test, transitive_dep = None, with_java_main = False):
     dependency_a_trans_dep_jar = transitive_dep
     if dependency_a_trans_dep_jar == None:
         dependency_a_trans_dep_jar = test.artifact(
@@ -29,14 +29,20 @@ def arrange(test, transitive_dep = None):
         ],
     )
 
+    main_srcs = [
+        test.artifact(
+            name = "main_target_library.kt",
+        ),
+    ]
+    if with_java_main:
+        main_srcs.append(test.artifact(
+            name = "MainTargetLibrary.java",
+        ))
+
     main_target_library = test.got(
         kt_jvm_library,
         name = "main_target_library",
-        srcs = [
-            test.artifact(
-                name = "main_target_library.kt",
-            ),
-        ],
+        srcs = main_srcs,
         deps = [
             dependency_a,
         ],

--- a/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
+++ b/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
@@ -195,6 +195,57 @@ def _test_classpath_experimental_prune_transitive_deps_prune_unmatched_maven_rep
         },
     )
 
+def _javac_inputs_assertions_(env, target):
+    # javac reads its arguments from a params file, so action.argv cannot be parsed for
+    # --classpath the way the worker's flagfile can. The action inputs are an equivalent
+    # assertion surface: a jar absent from the inputs cannot be on the compile classpath.
+    action = env.expect.that_target(target).action_named("Javac")
+
+    want_input_matchers = [
+        matching.file_basename_equals(abi_jar_of(f.basename))
+        for f in env.ctx.files.want_inputs
+        if not f.basename.endswith("jdeps")
+    ]
+    action.inputs().contains_at_least_predicates(want_input_matchers)
+
+    for f in env.ctx.files.not_want_inputs:
+        if not f.basename.endswith("jdeps"):
+            action.inputs().not_contains_predicate(matching.file_basename_equals(f.basename))
+
+def _make_javac_classpath_test(setting_value, not_want_transitive):
+    """The javac half of a mixed kt/java target must compile against the same (pruned or full)
+    classpath as the Kotlin half."""
+
+    def _case(test):
+        (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(
+            test,
+            with_java_main = True,
+        )
+
+        analysis_test(
+            name = test.name,
+            impl = _javac_inputs_assertions_,
+            target = main_target_library,
+            config_settings = {
+                str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): setting_value,
+                str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [],
+                str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+            },
+            attr_values = {
+                "not_want_inputs": [dependency_a_trans_dep_jar] if not_want_transitive else [],
+                "want_inputs": [dependency_a] if not_want_transitive else [
+                    dependency_a,
+                    dependency_a_trans_dep_jar,
+                ],
+            },
+            attrs = {
+                "not_want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+                "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            },
+        )
+
+    return _case
+
 def experimental_prune_transitive_deps_tests(name):
     suite(
         name,
@@ -202,4 +253,6 @@ def experimental_prune_transitive_deps_tests(name):
         enabled_keep_maven_repository = _test_classpath_experimental_prune_transitive_deps_keep_maven_repository,
         enabled_prune_unmatched_maven_repository = _test_classpath_experimental_prune_transitive_deps_prune_unmatched_maven_repository,
         disabled = _test_classpath_experimental_prune_transitive_deps_False,
+        javac_enabled = _make_javac_classpath_test(True, True),
+        javac_disabled = _make_javac_classpath_test(False, False),
     )


### PR DESCRIPTION
… of mixed targets

- When experimental_prune_transitive_deps is enabled, compile target's Java sources with the same classpath the Kotlin sources are compiled against.
- Tests added.