### PR TITLE
Wire the experimental_build_tools_api build setting into the toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,19 +266,22 @@ Additionally, you can add options for both tracing and timing of the bazel build
 
 The Build Tools API is a modern compilation interface provided by JetBrains for invoking the Kotlin compiler. It offers better integration and is required for incremental compilation support.
 
-**This feature is enabled by default.**
+**This feature is an explicit opt-in.** By default rules_kotlin compiles through the legacy `K2JVMCompiler`;
 
-To disable the Build Tools API and use the legacy compilation approach, add the following flag to your build:
+To enable the Build Tools API for the whole build, add the following flag:
 
 ```bash
-bazel build --@rules_kotlin//kotlin/settings:experimental_build_tools_api=false //your:target
+bazel build --@rules_kotlin//kotlin/settings:experimental_build_tools_api=true //your:target
 ```
 
 Or add it to your `.bazelrc` file:
 
 ```
-build --@rules_kotlin//kotlin/settings:experimental_build_tools_api=false
+build --@rules_kotlin//kotlin/settings:experimental_build_tools_api=true
 ```
+
+Alternatively, enable it for a single toolchain via `define_kt_toolchain(experimental_build_tools_api = True)`.
+Either switch is sufficient; both default to `False`.
 
 # Pruning transitive dependencies
 

--- a/examples/dagger/BUILD
+++ b/examples/dagger/BUILD
@@ -105,5 +105,7 @@ java_binary(
 define_kt_toolchain(
     name = "kotlin_toolchain",
     api_version = "2.0",
+    # Dagger-generated code imports javax.annotation.processing.Generated (JDK 9+)
+    jvm_target = "11",
     language_version = "2.0",
 )

--- a/examples/dagger/MODULE.bazel
+++ b/examples/dagger/MODULE.bazel
@@ -27,3 +27,6 @@ maven.install(
     ],
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# Use the local toolchain (jvm_target 11): Dagger-generated code needs JDK 9+ platform APIs.
+register_toolchains("//:kotlin_toolchain")

--- a/examples/dagger/WORKSPACE
+++ b/examples/dagger/WORKSPACE
@@ -92,9 +92,8 @@ load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
 
 rules_jvm_external_setup()
 
-load("@rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
-
-kt_register_toolchains()
+# Use the local toolchain (jvm_target 11): Dagger-generated code needs JDK 9+ platform APIs.
+register_toolchains("//:kotlin_toolchain")
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 

--- a/examples/ksp/BUILD
+++ b/examples/ksp/BUILD
@@ -19,7 +19,11 @@ load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])
 
-define_kt_toolchain(name = "kotlin_toolchain")
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    # KSP-generated code imports javax.annotation.processing.Generated (JDK 9+)
+    jvm_target = "11",
+)
 
 # Generate a srcjar to validate intellij plugin correctly attaches it.
 genrule(

--- a/examples/ksp/MODULE.bazel
+++ b/examples/ksp/MODULE.bazel
@@ -33,3 +33,6 @@ maven.install(
     ],
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# Use the local toolchain (jvm_target 11): KSP-generated code needs JDK 9+ platform APIs.
+register_toolchains("//:kotlin_toolchain")

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -94,7 +94,7 @@ def _kotlin_toolchain_impl(ctx):
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
-        experimental_build_tools_api = ctx.attr.experimental_build_tools_api,
+        experimental_build_tools_api = ctx.attr.experimental_build_tools_api or ctx.attr._experimental_build_tools_api_setting[BuildSettingInfo].value,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -331,6 +331,12 @@ _kt_toolchain = rule(
             allow_single_file = True,
             cfg = "target",
             default = Label("//third_party:empty.jdeps"),
+        ),
+        "_experimental_build_tools_api_setting": attr.label(
+            doc = """Build setting enabling compilation with the Build Tools API for every toolchain in
+            the build. The effective toggle is this setting OR-ed with the per-toolchain
+            experimental_build_tools_api attr; both default to False (legacy compilation).""",
+            default = Label("//kotlin/settings:experimental_build_tools_api"),
         ),
         "_experimental_ksp2_psi_resolution": attr.label(
             doc = """If enabled, KSP2 uses its experimental PSI-based symbol resolution strategy

--- a/kotlin/settings/BUILD.bazel
+++ b/kotlin/settings/BUILD.bazel
@@ -54,7 +54,7 @@ bool_flag(
 
 bool_flag(
     name = "experimental_build_tools_api",
-    build_setting_default = True,
+    build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 

--- a/kotlin/settings/BUILD.release.bazel
+++ b/kotlin/settings/BUILD.release.bazel
@@ -46,7 +46,7 @@ bool_flag(
 # --@rules_kotlin//kotlin/settings:experimental_build_tools_api=True
 bool_flag(
     name = "experimental_build_tools_api",
-    build_setting_default = True,
+    build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
@@ -19,6 +19,7 @@ import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.getToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
 import org.jetbrains.kotlin.cli.common.ExitCode
@@ -49,6 +50,13 @@ class BuildToolsAPICompiler : KotlinCompiler {
     // Apply raw CLI arguments - this parses the args and sets all compiler options
     // TODO: we can use actual typed API after we get rid of BazelK2JVMCompiler and use BTAPI exclusively
     operationBuilder.compilerArguments.applyArgumentStrings(args.toList())
+
+    // The rules assemble the complete compile classpath themselves, including the Kotlin
+    // stdlib/reflect, so the compiler must not auto-append them from its own
+    // install location: that extra classpath root shadows explicitly declared dependencies.
+    // Applied after the user arguments so they cannot re-enable the Kotlin home discovery.
+    operationBuilder.compilerArguments[JvmCompilerArguments.NO_STDLIB] = true
+    operationBuilder.compilerArguments[JvmCompilerArguments.NO_REFLECT] = true
 
     // Execute the compilation
     val result =

--- a/src/test/starlark/rules/BUILD.bazel
+++ b/src/test/starlark/rules/BUILD.bazel
@@ -1,6 +1,11 @@
 load("//kotlin:core.bzl", "define_kt_toolchain")
 load(":associates_tests.bzl", "associates_tests")
+load(":build_tools_api_toggle_tests.bzl", "build_tools_api_toggle_tests")
 load(":experimental_prune_transitive_deps_tests.bzl", "experimental_prune_transitive_deps_tests")
+
+build_tools_api_toggle_tests(
+    name = "build_tools_api_toggle_tests",
+)
 
 experimental_prune_transitive_deps_tests(
     name = "experimental_prune_transitive_deps_tests",

--- a/src/test/starlark/rules/build_tools_api_toggle_tests.bzl
+++ b/src/test/starlark/rules/build_tools_api_toggle_tests.bzl
@@ -1,0 +1,42 @@
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("//src/test/starlark:case.bzl", "suite")
+load(":arrangement.bzl", "arrange")
+load(":util.bzl", "values_for_flag_of")
+
+def _lowercase(value):
+    return value.lower()
+
+def _build_tools_api_flag_assertion(env, target):
+    action = env.expect.that_target(target).action_named("KotlinCompile")
+    values_for_flag_of(action, "--build_tools_api").transform(
+        desc = "lowercased",
+        map_each = _lowercase,
+    ).contains_exactly([env.ctx.attr.want_value])
+
+def _make_toggle_test(setting_value, want_value):
+    def _case(test):
+        (_dependency_a_trans_dep_jar, _dependency_a, main_target_library) = arrange(test)
+
+        analysis_test(
+            name = test.name,
+            impl = _build_tools_api_flag_assertion,
+            target = main_target_library,
+            config_settings = {
+                str(Label("@rules_kotlin//kotlin/settings:experimental_build_tools_api")): setting_value,
+            },
+            attr_values = {
+                "want_value": want_value,
+            },
+            attrs = {
+                "want_value": attr.string(),
+            },
+        )
+
+    return _case
+
+def build_tools_api_toggle_tests(name):
+    suite(
+        name,
+        setting_disabled_compiles_via_legacy = _make_toggle_test(False, "false"),
+        setting_enabled_compiles_via_build_tools_api = _make_toggle_test(True, "true"),
+    )


### PR DESCRIPTION
- The //kotlin/settings:experimental_build_tools_api bool_flag was a no-op. Now the flag toggles compilation with Build Tools API for all kotlin toolchains.
- The toolchain now reads the setting via a BuildSettingInfo label attr; the effective toggle is the per-toolchain attr OR-ed with the build setting.
- Changed default value to 'False' making Build Tools API an explicit opt-in.
- README updated and tests added