### PR TITLE
Compile the Java half with the Kotlin compiler's fixed UTF-8 source e…

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1059,6 +1059,10 @@ def _run_kt_java_builder_actions(
         if len(srcs.kt) > 0:
             javac_opts.append("-proc:none")
 
+        # The Kotlin compiler reads .kt sources as hard-coded UTF-8
+        # Compile java half of a mixed target accordingly.
+        javac_opts.extend(["-encoding", "UTF-8"])
+
         # Compile the Java half for the same effective jvm_target, the kotlin part is compiled for.
         kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options
         jvm_target = kotlinc_options.jvm_target if (kotlinc_options and kotlinc_options.jvm_target) else toolchains.kt.jvm_target

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -1,10 +1,13 @@
 load(":export_only_module_name_test.bzl", "export_only_module_name_test_suite")
+load(":javac_encoding_test.bzl", "javac_encoding_test_suite")
 load(":javac_jvm_target_test.bzl", "javac_jvm_target_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
 load(":sourceless_library_test.bzl", "sourceless_library_test_suite")
 
 export_only_module_name_test_suite(name = "export_only_module_name_tests")
+
+javac_encoding_test_suite(name = "javac_encoding_tests")
 
 javac_jvm_target_test_suite(name = "javac_jvm_target_tests")
 

--- a/src/test/starlark/internal/jvm/javac_encoding_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_encoding_test.bzl
@@ -1,0 +1,66 @@
+"""Tests for the fixed UTF-8 source encoding on the Java half of kt_jvm targets."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//kotlin:jvm.bzl", "kt_jvm_library")
+
+def _javac_action(env):
+    actions = analysistest.target_actions(env)
+    javac_actions = [
+        action
+        for action in actions
+        if action.mnemonic == "Javac"
+    ]
+    asserts.equals(env, expected = 1, actual = len(javac_actions))
+    return javac_actions[0]
+
+def _value_of(env, argv, flag):
+    for i in range(len(argv) - 1):
+        if argv[i] == flag:
+            return argv[i + 1]
+    asserts.true(env, False, msg = "flag %s not found in the Javac action" % flag)
+    return None
+
+def _utf8_encoding_always_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # The Kotlin compiler reads sources as fixed UTF-8 with no option to change it, so the Java
+    # half must be compiled with the same hard-coded encoding even when no options are set.
+    asserts.equals(
+        env,
+        expected = "UTF-8",
+        actual = _value_of(env, _javac_action(env).argv, "-encoding"),
+    )
+
+    return analysistest.end(env)
+
+_utf8_encoding_always_test = analysistest.make(_utf8_encoding_always_test_impl)
+
+def _javac_encoding_contents():
+    write_file(
+        name = "javac_encoding_java_source",
+        out = "JavacEncodingSource.java",
+        content = ["class JavacEncodingSource {}"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_encoding_library",
+        srcs = ["javac_encoding_java_source"],
+        tags = ["manual"],
+    )
+
+    _utf8_encoding_always_test(
+        name = "utf8_encoding_always_test",
+        target_under_test = ":javac_encoding_library",
+    )
+
+def javac_encoding_test_suite(name):
+    _javac_encoding_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":utf8_encoding_always_test",
+        ],
+    )


### PR DESCRIPTION
…ncoding

The Kotlin compiler reads every source as UTF-8 => pass -encoding UTF-8 to the java_common.compile invocation unconditionally.