### PR TITLE
Derive the javac warning mode from the Kotlin warn option

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1070,6 +1070,15 @@ def _run_kt_java_builder_actions(
             else:
                 javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target))
 
+        # Compile the Java half with the same warning mode as the kotlin part, unless the javac
+        # options (or a plugin's) already set one: a single `warn` value governs the whole target.
+        if "-nowarn" not in javac_opts and "-Werror" not in javac_opts:
+            kotlinc_warn = getattr(kotlinc_options, "warn", None) if kotlinc_options else None
+            if kotlinc_warn == "off":
+                javac_opts.append("-nowarn")
+            elif kotlinc_warn == "error":
+                javac_opts.append("-Werror")
+
         java_info = java_common.compile(
             ctx,
             source_files = srcs.java,

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -1,5 +1,6 @@
 load(":export_only_module_name_test.bzl", "export_only_module_name_test_suite")
 load(":javac_jvm_target_test.bzl", "javac_jvm_target_test_suite")
+load(":javac_warn_test.bzl", "javac_warn_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
 load(":sourceless_library_test.bzl", "sourceless_library_test_suite")
@@ -7,6 +8,8 @@ load(":sourceless_library_test.bzl", "sourceless_library_test_suite")
 export_only_module_name_test_suite(name = "export_only_module_name_tests")
 
 javac_jvm_target_test_suite(name = "javac_jvm_target_tests")
+
+javac_warn_test_suite(name = "javac_warn_tests")
 
 jvm_deps_test_suite(name = "jvm_tests")
 

--- a/src/test/starlark/internal/jvm/javac_warn_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_warn_test.bzl
@@ -1,0 +1,136 @@
+"""Tests for deriving the javac warning mode from the Kotlin warn option."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//kotlin:core.bzl", "kt_kotlinc_options")
+load("//kotlin:jvm.bzl", "kt_javac_options", "kt_jvm_library")
+
+def _javac_action(env):
+    actions = analysistest.target_actions(env)
+    javac_actions = [
+        action
+        for action in actions
+        if action.mnemonic == "Javac"
+    ]
+    asserts.equals(env, expected = 1, actual = len(javac_actions))
+    return javac_actions[0]
+
+def _make_warn_flags_test(expected_present, expected_absent):
+    def _impl(ctx):
+        env = analysistest.begin(ctx)
+
+        argv = _javac_action(env).argv
+        for flag in expected_present:
+            asserts.true(
+                env,
+                flag in argv,
+                msg = "expected %s on the Javac action" % flag,
+            )
+        for flag in expected_absent:
+            asserts.false(
+                env,
+                flag in argv,
+                msg = "did not expect %s on the Javac action" % flag,
+            )
+
+        return analysistest.end(env)
+
+    return analysistest.make(_impl)
+
+# The Java half follows the Kotlin `warn` option when the javac options set none: a single warn
+# value governs the whole target.
+_warn_derived_from_kotlinc_error_test = _make_warn_flags_test(["-Werror"], ["-nowarn"])
+_warn_derived_from_kotlinc_off_test = _make_warn_flags_test(["-nowarn"], ["-Werror"])
+
+# An explicit javac-side warn wins over the derivation.
+_javac_warn_wins_test = _make_warn_flags_test(["-Werror"], ["-nowarn"])
+
+# Without options on either side (toolchain defaults are "report") no warn flag is emitted.
+_no_warn_flags_by_default_test = _make_warn_flags_test([], ["-nowarn", "-Werror"])
+
+def _javac_warn_contents():
+    write_file(
+        name = "javac_warn_java_source",
+        out = "JavacWarnSource.java",
+        content = ["class JavacWarnSource {}"],
+        tags = ["manual"],
+    )
+
+    kt_kotlinc_options(
+        name = "warn_error_kotlinc_options",
+        tags = ["manual"],
+        warn = "error",
+    )
+
+    kt_kotlinc_options(
+        name = "warn_off_kotlinc_options",
+        tags = ["manual"],
+        warn = "off",
+    )
+
+    kt_javac_options(
+        name = "warn_error_javac_options",
+        tags = ["manual"],
+        warn = "error",
+    )
+
+    kt_jvm_library(
+        name = "javac_warn_error_derived_library",
+        srcs = ["javac_warn_java_source"],
+        kotlinc_opts = ":warn_error_kotlinc_options",
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_warn_off_derived_library",
+        srcs = ["javac_warn_java_source"],
+        kotlinc_opts = ":warn_off_kotlinc_options",
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_warn_wins_library",
+        srcs = ["javac_warn_java_source"],
+        javac_opts = ":warn_error_javac_options",
+        kotlinc_opts = ":warn_off_kotlinc_options",
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_warn_default_library",
+        srcs = ["javac_warn_java_source"],
+        tags = ["manual"],
+    )
+
+    _warn_derived_from_kotlinc_error_test(
+        name = "warn_derived_from_kotlinc_error_test",
+        target_under_test = ":javac_warn_error_derived_library",
+    )
+
+    _warn_derived_from_kotlinc_off_test(
+        name = "warn_derived_from_kotlinc_off_test",
+        target_under_test = ":javac_warn_off_derived_library",
+    )
+
+    _javac_warn_wins_test(
+        name = "javac_warn_wins_test",
+        target_under_test = ":javac_warn_wins_library",
+    )
+
+    _no_warn_flags_by_default_test(
+        name = "no_warn_flags_by_default_test",
+        target_under_test = ":javac_warn_default_library",
+    )
+
+def javac_warn_test_suite(name):
+    _javac_warn_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":warn_derived_from_kotlinc_error_test",
+            ":warn_derived_from_kotlinc_off_test",
+            ":javac_warn_wins_test",
+            ":no_warn_flags_by_default_test",
+        ],
+    )


### PR DESCRIPTION
If not configured explicitly, derive javac warning flags from kotlinc options.