### PR TITLE
Introduce 'no_proc' option to explicitly disable java annotation proc…

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -9,8 +9,8 @@
 <pre>
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_javac_options")
 
-kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-add_exports">add_exports</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>,
-                 <a href="#kt_javac_options-x_lint">x_lint</a>, <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
+kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-add_exports">add_exports</a>, <a href="#kt_javac_options-no_proc">no_proc</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>,
+                 <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>, <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
 </pre>
 
 Define java compiler options for `kt_jvm_*` rules with java sources.
@@ -22,6 +22,7 @@ Define java compiler options for `kt_jvm_*` rules with java sources.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="kt_javac_options-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="kt_javac_options-add_exports"></a>add_exports |  Export internal jdk apis   | List of strings | optional |  `[]`  |
+| <a id="kt_javac_options-no_proc"></a>no_proc |  Disable java annotation processing (javac -proc:none). The Java half of a target with Kotlin sources is always compiled with -proc:none (Kotlin owns annotation processing there); this option extends that to Java-only kt_jvm_* targets.   | Boolean | optional |  `False`  |
 | <a id="kt_javac_options-release"></a>release |  Compile for the specified Java SE release   | String | optional |  `"default"`  |
 | <a id="kt_javac_options-warn"></a>warn |  Control warning behaviour.   | String | optional |  `"report"`  |
 | <a id="kt_javac_options-x_ep_disable_all_checks"></a>x_ep_disable_all_checks |  See javac -XepDisableAllChecks documentation   | Boolean | optional |  `False`  |
@@ -357,8 +358,8 @@ kt_jvm_library(
 <pre>
 load("@rules_kotlin//kotlin:core.bzl", "kt_javac_options")
 
-kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-add_exports">add_exports</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>,
-                 <a href="#kt_javac_options-x_lint">x_lint</a>, <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
+kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-add_exports">add_exports</a>, <a href="#kt_javac_options-no_proc">no_proc</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>,
+                 <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>, <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
 </pre>
 
 Define java compiler options for `kt_jvm_*` rules with java sources.
@@ -370,6 +371,7 @@ Define java compiler options for `kt_jvm_*` rules with java sources.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="kt_javac_options-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="kt_javac_options-add_exports"></a>add_exports |  Export internal jdk apis   | List of strings | optional |  `[]`  |
+| <a id="kt_javac_options-no_proc"></a>no_proc |  Disable java annotation processing (javac -proc:none). The Java half of a target with Kotlin sources is always compiled with -proc:none (Kotlin owns annotation processing there); this option extends that to Java-only kt_jvm_* targets.   | Boolean | optional |  `False`  |
 | <a id="kt_javac_options-release"></a>release |  Compile for the specified Java SE release   | String | optional |  `"default"`  |
 | <a id="kt_javac_options-warn"></a>warn |  Control warning behaviour.   | String | optional |  `"report"`  |
 | <a id="kt_javac_options-x_ep_disable_all_checks"></a>x_ep_disable_all_checks |  See javac -XepDisableAllChecks documentation   | Boolean | optional |  `False`  |

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1061,7 +1061,8 @@ def _run_kt_java_builder_actions(
     # the final ABI jar. Otherwise just use the KT ABI jar as final ABI jar.
     ksp_generated_java_src_jars = generated_ksp_src_jars and is_ksp_processor_generating_java(ctx.attr.plugins)
     if srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars:
-        javac_opts = javac_options_to_flags(ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options)
+        javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
+        javac_opts = javac_options_to_flags(javac_options)
         javac_opts.extend([
             flag
             for plugin in ctx.attr.plugins
@@ -1071,7 +1072,7 @@ def _run_kt_java_builder_actions(
 
         # Kotlin takes care of annotation processing. Note that JavaBuilder "discovers"
         # annotation processors in `deps` also.
-        if len(srcs.kt) > 0:
+        if len(srcs.kt) > 0 and not javac_options.no_proc:
             javac_opts.append("-proc:none")
 
         # The Kotlin compiler reads .kt sources as hard-coded UTF-8

--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -35,6 +35,16 @@ _JOPTS = {
             derive.info: derive.format_key_value_for("-A", "{name}{key}={value}"),
         },
     ),
+    "no_proc": struct(
+        args = dict(
+            default = False,
+            doc = "Disable java annotation processing (javac -proc:none). The Java half of a target with Kotlin sources is always compiled with -proc:none (Kotlin owns annotation processing there); this option extends that to Java-only kt_jvm_* targets.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-proc:none"],
+        },
+    ),
     "release": struct(
         args = dict(
             default = "default",

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -1,6 +1,7 @@
 load(":export_only_module_name_test.bzl", "export_only_module_name_test_suite")
 load(":javac_encoding_test.bzl", "javac_encoding_test_suite")
 load(":javac_jvm_target_test.bzl", "javac_jvm_target_test_suite")
+load(":javac_options_test.bzl", "javac_options_test_suite")
 load(":javac_warn_test.bzl", "javac_warn_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kotlinc_options_test.bzl", "kotlinc_options_test_suite")
@@ -12,6 +13,8 @@ export_only_module_name_test_suite(name = "export_only_module_name_tests")
 javac_encoding_test_suite(name = "javac_encoding_tests")
 
 javac_jvm_target_test_suite(name = "javac_jvm_target_tests")
+
+javac_options_test_suite(name = "javac_options_tests")
 
 javac_warn_test_suite(name = "javac_warn_tests")
 

--- a/src/test/starlark/internal/jvm/javac_options_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_options_test.bzl
@@ -1,0 +1,167 @@
+"""Tests for disabling java annotation processing via the no_proc javac option."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("//kotlin:jvm.bzl", "kt_javac_options", "kt_jvm_library")
+
+def _javac_action(env):
+    actions = analysistest.target_actions(env)
+    javac_actions = [
+        action
+        for action in actions
+        if action.mnemonic == "Javac"
+    ]
+    asserts.equals(env, expected = 1, actual = len(javac_actions))
+    return javac_actions[0]
+
+def _no_proc_reaches_javac_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # A java-only target: the -proc:none for targets with Kotlin sources does not apply, so the
+    # flag can only come from the no_proc option.
+    asserts.true(
+        env,
+        "-proc:none" in _javac_action(env).argv,
+        msg = "kt_javac_options(no_proc = True) should reach the Javac action as -proc:none",
+    )
+
+    return analysistest.end(env)
+
+_no_proc_reaches_javac_test = analysistest.make(_no_proc_reaches_javac_test_impl)
+
+def _no_proc_off_by_default_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    asserts.false(
+        env,
+        "-proc:none" in _javac_action(env).argv,
+        msg = "annotation processing must stay enabled for java-only targets by default",
+    )
+
+    return analysistest.end(env)
+
+_no_proc_off_by_default_test = analysistest.make(_no_proc_off_by_default_test_impl)
+
+def _mixed_target_no_proc_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # A target with Kotlin sources compiles its Java half with -proc:none regardless of options:
+    # Kotlin owns annotation processing there.
+    argv = _javac_action(env).argv
+    asserts.true(
+        env,
+        "-proc:none" in argv,
+        msg = "the java half of a mixed target must always be compiled with -proc:none",
+    )
+    asserts.equals(
+        env,
+        expected = 1,
+        actual = len([arg for arg in argv if arg == "-proc:none"]),
+    )
+
+    return analysistest.end(env)
+
+_mixed_target_no_proc_test = analysistest.make(_mixed_target_no_proc_test_impl)
+
+def _mixed_target_explicit_no_proc_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    # A mixed target whose options also set no_proc must not end up with a duplicated flag: the
+    # options render -proc:none themselves, and the Kotlin-sources rule detects that via the
+    # option value.
+    argv = _javac_action(env).argv
+    asserts.equals(
+        env,
+        expected = 1,
+        actual = len([arg for arg in argv if arg == "-proc:none"]),
+    )
+
+    return analysistest.end(env)
+
+_mixed_target_explicit_no_proc_test = analysistest.make(_mixed_target_explicit_no_proc_test_impl)
+
+def _javac_options_contents():
+    write_file(
+        name = "javac_flags_java_source",
+        out = "JavacFlagsSource.java",
+        content = ["class JavacFlagsSource {}"],
+        tags = ["manual"],
+    )
+
+    write_file(
+        name = "javac_flags_kt_source",
+        out = "JavacFlagsSource.kt",
+        content = ["class JavacFlagsKotlinSource"],
+        tags = ["manual"],
+    )
+
+    kt_javac_options(
+        name = "no_proc_javac_options",
+        no_proc = True,
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_no_proc_library",
+        srcs = ["javac_flags_java_source"],
+        javac_opts = ":no_proc_javac_options",
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_default_options_library",
+        srcs = ["javac_flags_java_source"],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_mixed_library",
+        srcs = [
+            "javac_flags_java_source",
+            "javac_flags_kt_source",
+        ],
+        tags = ["manual"],
+    )
+
+    kt_jvm_library(
+        name = "javac_mixed_no_proc_library",
+        srcs = [
+            "javac_flags_java_source",
+            "javac_flags_kt_source",
+        ],
+        javac_opts = ":no_proc_javac_options",
+        tags = ["manual"],
+    )
+
+    _no_proc_reaches_javac_test(
+        name = "no_proc_reaches_the_javac_action_test",
+        target_under_test = ":javac_no_proc_library",
+    )
+
+    _no_proc_off_by_default_test(
+        name = "no_proc_off_by_default_test",
+        target_under_test = ":javac_default_options_library",
+    )
+
+    _mixed_target_no_proc_test(
+        name = "mixed_target_no_proc_test",
+        target_under_test = ":javac_mixed_library",
+    )
+
+    _mixed_target_explicit_no_proc_test(
+        name = "mixed_target_explicit_no_proc_test",
+        target_under_test = ":javac_mixed_no_proc_library",
+    )
+
+def javac_options_test_suite(name):
+    _javac_options_contents()
+
+    native.test_suite(
+        name = name,
+        tests = [
+            ":no_proc_reaches_the_javac_action_test",
+            ":no_proc_off_by_default_test",
+            ":mixed_target_no_proc_test",
+            ":mixed_target_explicit_no_proc_test",
+        ],
+    )


### PR DESCRIPTION
…essing

This option allows to explicitly turn off annotation processing for kt_jvm_* targets containing only .java sources.