### PR TITLE
Invoke KSP2 through explicit interface instead of reflection

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2EntryPoint.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2EntryPoint.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm
+
+import java.io.File
+
+/**
+ * The typed contract between the KSP2 worker and the Ksp2Invoker implementation loaded in the
+ * KSP2 classloader.
+ *
+ * The worker defines this interface and the invoker implements it; because the KSP2 classloader
+ * parents to the worker's classloader, both sides see the same interface class and the worker
+ * invokes the implementation directly instead of looking the method up reflectively. Only JDK
+ * types cross the boundary, so the contract does not leak KSP types into the worker.
+ */
+interface Ksp2EntryPoint {
+  /**
+   * Execute KSP2 with the given configuration.
+   *
+   * @param logLevel Logger level (0=ERROR, 1=WARN, 2=INFO, 3=LOGGING)
+   * @return Exit code (0 for success)
+   */
+  @Suppress("LongParameterList")
+  fun execute(
+    moduleName: String,
+    sourceRoots: List<File>,
+    javaSourceRoots: List<File>,
+    libraries: List<File>,
+    kotlinOutputDir: File,
+    javaOutputDir: File,
+    classOutputDir: File,
+    resourceOutputDir: File,
+    cachesDir: File,
+    projectBaseDir: File,
+    outputBaseDir: File,
+    jvmTarget: String?,
+    languageVersion: String?,
+    apiVersion: String?,
+    jdkHome: File?,
+    processorOptions: Map<String, String> = emptyMap(),
+    experimentalPsiResolution: Boolean = false,
+    logLevel: Int = 1,
+  ): Int
+}

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
@@ -243,57 +243,33 @@ class Ksp2Task : Work {
         argMap.optionalSingle(Ksp2Flags.EXPERIMENTAL_PSI_RESOLUTION)?.toBoolean() ?: false
 
       // Load Ksp2Invoker via reflection (it's compiled against KSP2 classes)
-      val invokerClass = kspClassLoader.loadClass("io.bazel.kotlin.ksp2.Ksp2Invoker")
       val invoker =
-        invokerClass
-          .getConstructor(ClassLoader::class.java)
-          .newInstance(kspClassLoader)
-      val executeMethod =
-        invokerClass.getMethod(
-          "execute",
-          String::class.java, // moduleName
-          List::class.java, // sourceRoots
-          List::class.java, // javaSourceRoots
-          List::class.java, // libraries
-          File::class.java, // kotlinOutputDir
-          File::class.java, // javaOutputDir
-          File::class.java, // classOutputDir
-          File::class.java, // resourceOutputDir
-          File::class.java, // cachesDir
-          File::class.java, // projectBaseDir
-          File::class.java, // outputBaseDir
-          String::class.java, // jvmTarget
-          String::class.java, // languageVersion
-          String::class.java, // apiVersion
-          File::class.java, // jdkHome
-          Map::class.java, // processorOptions
-          Boolean::class.javaPrimitiveType, // experimentalPsiResolution
-          Int::class.java, // logLevel
-        )
+        kspClassLoader
+          .loadClass("io.bazel.kotlin.ksp2.Ksp2Invoker")
+          .getDeclaredConstructor()
+          .newInstance() as Ksp2EntryPoint
 
       // Execute KSP2
       val code =
-        executeMethod.invoke(
-          invoker,
-          moduleName,
-          sourceRoots.map { File(it) },
-          javaSourceRoots.map { File(it) },
-          argMap.optional(Ksp2Flags.LIBRARIES)?.map { File(it) } ?: emptyList<File>(),
-          kotlinOutputDir.toFile(),
-          javaOutputDir.toFile(),
-          classOutputDir.toFile(),
-          resourceOutputDir.toFile(),
-          cachesDir.toFile(),
-          kspWorkDir.toFile(), // projectBaseDir
-          kspWorkDir.toFile(), // outputBaseDir
-          argMap.optionalSingle(Ksp2Flags.JVM_TARGET),
-          argMap.optionalSingle(Ksp2Flags.LANGUAGE_VERSION),
-          argMap.optionalSingle(Ksp2Flags.API_VERSION),
-          argMap.optionalSingle(Ksp2Flags.JDK_HOME)?.let { File(it) },
-          processorOptions,
-          experimentalPsiResolution,
-          1, // logLevel
-        ) as Int
+        invoker.execute(
+          moduleName = moduleName,
+          sourceRoots = sourceRoots.map { File(it) },
+          javaSourceRoots = javaSourceRoots.map { File(it) },
+          libraries = argMap.optional(Ksp2Flags.LIBRARIES)?.map { File(it) } ?: emptyList(),
+          kotlinOutputDir = kotlinOutputDir.toFile(),
+          javaOutputDir = javaOutputDir.toFile(),
+          classOutputDir = classOutputDir.toFile(),
+          resourceOutputDir = resourceOutputDir.toFile(),
+          cachesDir = cachesDir.toFile(),
+          projectBaseDir = kspWorkDir.toFile(),
+          outputBaseDir = kspWorkDir.toFile(),
+          jvmTarget = argMap.optionalSingle(Ksp2Flags.JVM_TARGET),
+          languageVersion = argMap.optionalSingle(Ksp2Flags.LANGUAGE_VERSION),
+          apiVersion = argMap.optionalSingle(Ksp2Flags.API_VERSION),
+          jdkHome = argMap.optionalSingle(Ksp2Flags.JDK_HOME)?.let { File(it) },
+          processorOptions = processorOptions,
+          experimentalPsiResolution = experimentalPsiResolution,
+        )
 
       if (code != 0) {
         taskContext.error { "KSP2 failed with exit code: $code" }

--- a/src/main/kotlin/io/bazel/kotlin/ksp2/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/ksp2/BUILD.bazel
@@ -14,7 +14,9 @@
 
 load("//src/main/kotlin:bootstrap.bzl", "kt_bootstrap_library")
 
-# KSP2 invoker library, loaded at runtime in the KSP2 classloader.
+# KSP2 invoker library, loaded at runtime in the KSP2 classloader. The dep on the worker's tasks
+# library provides the Ksp2EntryPoint contract the invoker implements; the KSP2 classloader
+# resolves that interface from its parent (the worker), so the dep never rides along at runtime.
 kt_bootstrap_library(
     name = "ksp2",
     srcs = glob(["*.kt"]),
@@ -24,4 +26,7 @@ kt_bootstrap_library(
         "//kotlin/compiler:symbol-processing-common-deps",
     ],
     visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
+    ],
 )

--- a/src/main/kotlin/io/bazel/kotlin/ksp2/Ksp2Invoker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/ksp2/Ksp2Invoker.kt
@@ -19,6 +19,7 @@ import com.google.devtools.ksp.impl.KotlinSymbolProcessing
 import com.google.devtools.ksp.processing.KSPJvmConfig
 import com.google.devtools.ksp.processing.KspGradleLogger
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import io.bazel.kotlin.builder.tasks.jvm.Ksp2EntryPoint
 import java.io.File
 import java.util.ServiceLoader
 
@@ -30,16 +31,8 @@ import java.util.ServiceLoader
  * pattern as BuildToolsAPICompiler.
  */
 @Suppress("unused")
-class Ksp2Invoker(
-  private val classLoader: ClassLoader,
-) {
-  /**
-   * Execute KSP2 with the given configuration.
-   *
-   * @param logLevel Logger level (0=ERROR, 1=WARN, 2=INFO, 3=LOGGING)
-   * @return Exit code (0 for success)
-   */
-  fun execute(
+class Ksp2Invoker : Ksp2EntryPoint {
+  override fun execute(
     moduleName: String,
     sourceRoots: List<File>,
     javaSourceRoots: List<File>,
@@ -55,13 +48,15 @@ class Ksp2Invoker(
     languageVersion: String?,
     apiVersion: String?,
     jdkHome: File?,
-    processorOptions: Map<String, String> = emptyMap(),
-    experimentalPsiResolution: Boolean = false,
-    logLevel: Int = 1,
+    processorOptions: Map<String, String>,
+    experimentalPsiResolution: Boolean,
+    logLevel: Int,
   ): Int {
-    // Load processors via ServiceLoader from the provided classloader
+    // Load processors via ServiceLoader from this class's own defining classloader
     val processors =
-      ServiceLoader.load(SymbolProcessorProvider::class.java, classLoader).toList()
+      ServiceLoader
+        .load(SymbolProcessorProvider::class.java, Ksp2Invoker::class.java.classLoader)
+        .toList()
 
     // Build KSP2 configuration
     val kspConfig =

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -131,6 +131,7 @@ kt_rules_test(
     deps = [
         "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils",
+        "//src/main/kotlin/io/bazel/kotlin/ksp2",
         "@kotlin_rules_maven_test//:com_google_truth_truth",
         "@kotlin_rules_maven_test//:junit_junit",
     ],

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
@@ -17,6 +17,7 @@
 package io.bazel.kotlin.builder.tasks
 
 import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.builder.tasks.jvm.Ksp2EntryPoint
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.Ksp2Flags
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.clearKspClassLoaderCacheForTesting
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.fingerprintOf
@@ -281,5 +282,13 @@ class Ksp2TaskTest {
     val fp = fingerprintOf(listOf(jar.absolutePath))
     assertThat(fp).hasLength(64)
     assertThat(fp).matches("[0-9a-f]{64}")
+  }
+
+  @Test
+  fun testInvokerImplementsTheTypedEntryPoint() {
+    // The worker should implement the Ksp2EntryPoint contract
+    val invokerClass =
+      Class.forName("io.bazel.kotlin.ksp2.Ksp2Invoker", false, javaClass.classLoader)
+    assertThat(Ksp2EntryPoint::class.java.isAssignableFrom(invokerClass)).isTrue()
   }
 }


### PR DESCRIPTION
- Introduce explicit invocation contract for the Ksp2Invoker defined in Ksp2EntryPoint interface