### PR TITLE
Record type alias declarations in jdeps

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/declaration/FileChecker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/declaration/FileChecker.kt
@@ -27,8 +27,12 @@ internal class FileChecker(
     declaration.imports.filterIsInstance<FirResolvedImport>().forEach { import ->
       // check for classlike import (class, interface, object, enum, annotation, etc)
       if (import.resolvesToClass(context)) {
-        import.classId()?.resolveToClass(context)?.let {
-          classUsageRecorder.recordClass(it, context)
+        import.classId()?.let { classId ->
+          // A type alias is erased from the bytecode, so only the expanded class shows up in
+          // the compilation output. Record the alias declaration too, otherwise the target
+          // owning it is reported unused even though the import cannot resolve without it.
+          classId.resolveToTypeAlias(context)?.let { classUsageRecorder.recordClass(it, context) }
+          classId.resolveToClass(context)?.let { classUsageRecorder.recordClass(it, context) }
         }
       } else {
         // check for function import
@@ -107,3 +111,6 @@ private fun ClassId.resolveToClass(context: CheckerContext): FirRegularClassSymb
     is FirAnonymousObjectSymbol -> null
   }
 }
+
+private fun ClassId.resolveToTypeAlias(context: CheckerContext): FirTypeAliasSymbol? =
+  context.session.symbolProvider.getClassLikeSymbolByClassId(this) as? FirTypeAliasSymbol

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -1219,6 +1219,62 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
   }
 
   @Test
+  fun `type alias in dependency should be an explicit dependency`() {
+    val aliasedClassTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:aliasedClass")
+      c.addSource(
+        "AliasedClass.kt",
+        """
+          package dependency.aliased
+
+          class AliasedClass
+        """,
+      )
+      c.compileKotlin()
+    }
+
+    val typeAliasTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:typeAlias")
+      c.addSource(
+        "ClassAlias.kt",
+        """
+          package dependency.alias
+
+          import dependency.aliased.AliasedClass
+
+          typealias ClassAlias = AliasedClass
+        """,
+      )
+      c.addDirectDependencies(aliasedClassTarget)
+      c.compileKotlin()
+    }
+
+    val dependingTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:dependingTarget")
+      c.addSource(
+        "HasTypeAliasDependency.kt",
+        """
+          package something
+
+          import dependency.alias.ClassAlias
+
+          val property = ClassAlias()
+        """,
+      )
+      c.addDirectDependencies(typeAliasTarget, aliasedClassTarget)
+    }
+
+    val jdeps = depsProto(dependingTarget)
+    val expected = Deps.Dependencies.newBuilder()
+      .setRuleLabel("//:dependingTarget")
+      .setSuccess(true)
+      .addExplicitDep(typeAliasTarget.singleCompileJar())
+      .addExplicitDep(aliasedClassTarget.singleCompileJar())
+      .buildSorted()
+    assertThat(jdeps).isEqualTo(expected)
+  }
+
+  @Test
   fun `implement interface reference should be an explicit dependency`() {
     val indirectInterfaceDef = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource(


### PR DESCRIPTION
## Summary

When a source file imports a Kotlin `typealias` that lives in a different target than the class it expands to, the jdeps compiler plugin only records the expanded class. The target that owns the alias declaration is therefore reported as `UNUSED`, so `report_unused_deps = "error"` fails a build whose dependency is in fact required — removing the dep makes compilation fail with an unresolved reference.

The alias is a compile-time-only construct that is erased from the bytecode, so no amount of post-hoc jar inspection can recover it; the information is only available in the frontend, where the plugin already resolves the import.

## Repro

Three targets:

```kotlin
// //:aliasedClass
package dependency.aliased

class AliasedClass
```

```kotlin
// //:typeAlias  (deps = ["//:aliasedClass"])
package dependency.alias

import dependency.aliased.AliasedClass

typealias ClassAlias = AliasedClass
```

```kotlin
// //:dependingTarget  (deps = ["//:typeAlias", "//:aliasedClass"])
package something

import dependency.alias.ClassAlias

val property = ClassAlias()
```

Expected: both `//:typeAlias` and `//:aliasedClass` are explicit deps of `//:dependingTarget`.

Actual: `//:aliasedClass` is `EXPLICIT`, `//:typeAlias` is `UNUSED`:

```
dependency {
  path: ".../jar_file.jar"   # the alias target
  kind: UNUSED
}
```

With `report_unused_deps = "error"`, `JdepsMerge` then fails:

```
Please remove the following dependencies: //:typeAlias from //:dependingTarget
```

but dropping it fails compilation with `unresolved reference 'ClassAlias'`.

Reproduced on both `enableK2Compiler = true` and `false`.

## Cause

`FileChecker` resolves a class-like import via `ClassId.resolveToClass`, which maps a `FirTypeAliasSymbol` through `fullyExpandedClass(session)` and records only the resulting `FirRegularClassSymbol`. The alias symbol itself — and hence the jar that declares it — is never passed to `ClassUsageRecorder`.

## Fix

Record the alias symbol in addition to its expanded class when an import resolves to a class-like symbol.

The new regression test fails on master (`kind: UNUSED`, both K2 parameterizations) and passes with the change. The full `KotlinBuilderJvmJdepsTest` suite (98 cases) plus the rest of `//src/test/kotlin/io/bazel/kotlin/builder/tasks:tasks_tests`, including `KotlinBuilderJvmStrictDepsTest`, stay green.

## Impact

This is not a corner case in a large monorepo: any "alias for an identifier type" pattern (`typealias OSID = CoreOSID` in a utility target aliasing a core type) hits it, and today the only workarounds are an unused-deps allowlist entry per label, rewriting call sites to import the underlying class, or having the alias target `exports` the aliased one.

Note that the effect of fixing this is bidirectional: once alias owners count as used, strict-deps will start requiring direct deps on alias-owning targets that currently resolve transitively, so consumers should expect a one-time "add the following dependencies" sweep after upgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
