### PR TITLE
Use associates' COMPILE jars as friends when abi jars retain internal…

### DIFF
--- a/kotlin/internal/jvm/associates.bzl
+++ b/kotlin/internal/jvm/associates.bzl
@@ -30,18 +30,26 @@ def _collect_associates(ctx, toolchains, associate):
     them as a depset.
 
     There are three outcomes for this marco:
-    1. When `experimental_remove_private_classes_in_abi_jars` is enabled and the tag override has not been provided, only the
-        direct java_output CLASS jars will be collected for each associate target. Due to the stripping of internal and private
-        symbols from the compile jar, class jar is the only one that will contain the internal symbols an associate has access to.
+    1. When `experimental_treat_internal_as_private_in_abi_jars` is effective (together with
+        `experimental_remove_private_classes_in_abi_jars`, which it requires) and the tag overrides have not been
+        provided, only the direct java_output CLASS jars will be collected for each associate target. Internal symbols
+        are stripped from the compile jars in that configuration, so the class jar is the only one that contains the
+        internal symbols an associate has access to. With `experimental_remove_private_classes_in_abi_jars` alone,
+        internal symbols remain available in abi jars, so it is still possible to collect COMPILE jars
     2. When `experimental_strict_associate_dependencies` is enabled and the tag override has not been provided, only the
         direct java_output COMPILE jars will be collected for each associate target.
     3. When `experimental_strict_associate_dependencies` is disabled, the complete transitive set of compile jars will
         be collected for each assoicate target.
     """
+    internals_stripped_from_abi_jars = (
+        toolchains.kt.experimental_treat_internal_as_private_in_abi_jars and
+        "kt_treat_internal_as_private_in_abi_plugin_incompatible" not in ctx.attr.tags and
+        toolchains.kt.experimental_remove_private_classes_in_abi_jars and
+        "kt_remove_private_classes_in_abi_plugin_incompatible" not in ctx.attr.tags
+    )
     jars_depset = None
     abi_jars_set = _sets.make()
-    if (not "kt_remove_private_classes_in_abi_plugin_incompatible" in ctx.attr.tags and
-        toolchains.kt.experimental_remove_private_classes_in_abi_jars):
+    if internals_stripped_from_abi_jars:
         jars_depset = depset(direct = [a.class_jar for a in associate[JavaInfo].java_outputs])
         abi_jars_set = _sets.union(abi_jars_set, _sets.make([a.compile_jar for a in associate[JavaInfo].java_outputs]))
     elif (toolchains.kt.experimental_strict_associate_dependencies and

--- a/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
+++ b/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
@@ -74,6 +74,7 @@ def _strict_abi_test_impl(env, target):
     strict_abi_configured_toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = True,
+            experimental_treat_internal_as_private_in_abi_jars = True,
             experimental_prune_transitive_deps = True,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = True,
@@ -109,6 +110,7 @@ def _fat_abi_test_impl(env, target):
     fat_abi_configured_toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
+            experimental_treat_internal_as_private_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
@@ -159,6 +161,7 @@ def _transitive_from_exports_test_impl(env, target):
     strict_abi_configured_toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = True,
+            experimental_treat_internal_as_private_in_abi_jars = True,
             experimental_prune_transitive_deps = True,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = True,
@@ -228,6 +231,7 @@ def _transitive_from_associates_test_impl(env, target):
     nothing_configured_toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
+            experimental_treat_internal_as_private_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
@@ -280,8 +284,57 @@ def _abi_test(name, impl):
         },
     )
 
+def _remove_private_only_friends_test_impl(env, target):
+    # With private classes removed from abi jars but internals kept (treat_internal disabled),
+    # the friend set must stay the associate's compile-jar closure: internal symbols live in
+    # every abi jar, so members of the same module keep internal access to everything the
+    # module compiles against, exactly as if they were compiled together.
+    exported_dep_java_info = JavaInfo(
+        compile_jar = _file(env.ctx.attr.direct_dep_abi_jar),
+        output_jar = _file(env.ctx.attr.direct_dep_jar),
+    )
+    associate_java_info = JavaInfo(
+        compile_jar = _file(env.ctx.attr.associate_abi_jar),
+        output_jar = _file(env.ctx.attr.associate_jar),
+        exports = [exported_dep_java_info],
+    )
+    associate_deps = [{
+        JavaInfo: associate_java_info,
+        _KtJvmInfo: _KtJvmInfo(module_name = "associate_name"),
+    }]
+    fake_ctx = struct(label = target.label, attr = struct(module_name = "", tags = []))
+
+    remove_private_only_toolchains = struct(
+        kt = struct(
+            experimental_remove_private_classes_in_abi_jars = True,
+            experimental_treat_internal_as_private_in_abi_jars = False,
+            experimental_prune_transitive_deps = False,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
+            experimental_strict_associate_dependencies = False,
+            jvm_stdlibs = JavaInfo(
+                compile_jar = _file(env.ctx.attr.jvm_jar),
+                output_jar = _file(env.ctx.attr.jvm_jar),
+            ),
+        ),
+    )
+
+    result = _jvm_deps_utils.jvm_deps(
+        ctx = fake_ctx,
+        toolchains = remove_private_only_toolchains,
+        associate_deps = associate_deps,
+        deps = [],
+    )
+
+    friends = env.expect.that_depset_of_files(result.associate_jars)
+    friends.contains(_file(env.ctx.attr.associate_abi_jar).short_path)
+    friends.contains(_file(env.ctx.attr.direct_dep_abi_jar).short_path)
+    friends.not_contains(_file(env.ctx.attr.associate_jar).short_path)
+
 def _strict_abi_test(name):
     _abi_test(name, _strict_abi_test_impl)
+
+def _remove_private_only_friends_test(name):
+    _abi_test(name, _remove_private_only_friends_test_impl)
 
 def _fat_abi_test(name):
     _abi_test(name, _fat_abi_test_impl)
@@ -340,6 +393,7 @@ def _dep_infos_ordering_test_impl(env, target):
     toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
+            experimental_treat_internal_as_private_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
@@ -431,6 +485,7 @@ def _kept_transitive_repository_deduplication_test_impl(env, target):
     toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
+            experimental_treat_internal_as_private_in_abi_jars = False,
             experimental_prune_transitive_deps = True,
             experimental_prune_transitive_deps_keep_transitive_repositories = [shared_transitive_jar.owner.repo_name],
             experimental_strict_associate_dependencies = False,
@@ -543,6 +598,7 @@ def _pruned_java_deps_are_neverlink_test_impl(env, target):
     toolchains = struct(
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
+            experimental_treat_internal_as_private_in_abi_jars = False,
             experimental_prune_transitive_deps = True,
             experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
@@ -658,6 +714,7 @@ def jvm_deps_test_suite(name):
         name,
         tests = [
             _strict_abi_test,
+            _remove_private_only_friends_test,
             _fat_abi_test,
             _transitive_from_exports_test,
             _transitive_from_associates_test,

--- a/src/test/starlark/rules/BUILD.bazel
+++ b/src/test/starlark/rules/BUILD.bazel
@@ -23,3 +23,13 @@ define_kt_toolchain(
     experimental_strict_kotlin_deps = "error",
     experimental_use_abi_jars = True,
 )
+
+# Only used by associates_tests, which pulls it in with --extra_toolchains.
+define_kt_toolchain(
+    name = "treat_internal_as_private_toolchain",
+    experimental_remove_private_classes_in_abi_jars = True,
+    experimental_report_unused_deps = "error",
+    experimental_strict_kotlin_deps = "error",
+    experimental_treat_internal_as_private_in_abi_jars = True,
+    experimental_use_abi_jars = True,
+)

--- a/src/test/starlark/rules/associates_tests.bzl
+++ b/src/test/starlark/rules/associates_tests.bzl
@@ -6,9 +6,15 @@ load("//kotlin:jvm.bzl", "kt_jvm_library")
 load("//src/test/starlark:case.bzl", "suite")
 load(":util.bzl", "basename_of", "values_for_flag_of")
 
-# A toolchain with experimental_remove_private_classes_in_abi_jars enabled, which makes associates
-# contribute their class jar - rather than their compile jar - to the classpath.
+# A toolchain with experimental_remove_private_classes_in_abi_jars enabled. Removing private
+# classes keeps internal symbols in the compile jars, so associates keep contributing their
+# compile jar to the classpath.
 _REMOVE_PRIVATE_CLASSES_TOOLCHAIN = Label("//src/test/starlark/rules:remove_private_classes_toolchain")
+
+# A toolchain that additionally enables experimental_treat_internal_as_private_in_abi_jars, which
+# strips internal symbols from the compile jars and therefore makes associates contribute their
+# class jar - rather than their compile jar - to the classpath.
+_TREAT_INTERNAL_AS_PRIVATE_TOOLCHAIN = Label("//src/test/starlark/rules:treat_internal_as_private_toolchain")
 
 def _arrange(test):
     associate = test.have(
@@ -54,11 +60,11 @@ def _test_associate_jars_are_direct_dependencies(test):
     )
 
 def _associate_class_jar_is_direct_dependency_(env, target):
-    """With private class removal on, the class jar of the associate is the one that has to be declared.
+    """With internal stripping on, the class jar of the associate is the one that has to be declared.
 
-    Its compile jar no longer carries the internal symbols an associate is allowed to see, so
-    associates.bzl swaps in the class jar. Declaring the compile jar instead leaves the class jar
-    undeclared on the classpath.
+    Under experimental_treat_internal_as_private_in_abi_jars the compile jar no longer carries the
+    internal symbols an associate is allowed to see, so associates.bzl swaps in the class jar.
+    Declaring the compile jar instead leaves the class jar undeclared on the classpath.
     """
     _associate_jars_are_direct_dependencies_(env, target)
 
@@ -87,10 +93,55 @@ def _associate_class_jar_is_direct_dependency_(env, target):
         matching.file_basename_equals("%s_associate.abi.jar" % env.ctx.attr.namespace),
     ])
 
-def _test_associate_class_jar_is_direct_dependency_with_remove_private_classes(test):
+def _test_associate_class_jar_is_direct_dependency_with_treat_internal_as_private(test):
     analysis_test(
         name = test.name,
         impl = _associate_class_jar_is_direct_dependency_,
+        target = _arrange(test),
+        config_settings = {
+            "//command_line_option:extra_toolchains": [str(_TREAT_INTERNAL_AS_PRIVATE_TOOLCHAIN)],
+        },
+        attr_values = {
+            "namespace": test.name,
+        },
+        attrs = {
+            "namespace": attr.string(),
+        },
+    )
+
+def _associate_compile_jar_stays_(env, target):
+    """With private class removal alone, the compile jar of the associate stays on the classpath.
+
+    Removing private classes does not strip internal symbols from the compile jars (private
+    classes never take part in cross-target access), so the compile jar remains a usable friend
+    and there is no reason to swap in the class jar.
+    """
+    _associate_jars_are_direct_dependencies_(env, target)
+
+    action = env.expect.that_target(target).action_named("KotlinCompile")
+    direct_dependencies = values_for_flag_of(action, "--direct_dependencies").transform(
+        desc = "basenames",
+        map_each = basename_of,
+    )
+    direct_dependencies.contains("%s_associate.abi.jar" % env.ctx.attr.namespace)
+
+    # The class jar is not part of the compile classpath in this configuration.
+    values_for_flag_of(action, "--classpath").transform(
+        desc = "basenames",
+        map_each = basename_of,
+    ).contains_none_of(["%s_associate.jar" % env.ctx.attr.namespace])
+
+    # The jar the associate contributed to the classpath is available to the merger, which reads
+    # the owning label from the manifest of every jar the jdeps mention.
+    jdeps_merge = env.expect.that_target(target).action_named("JdepsMerge")
+    jdeps_merge.inputs().contains_at_least_predicates([
+        matching.file_basename_equals("%s_associate.abi.jar" % env.ctx.attr.namespace),
+    ])
+
+def _test_associate_compile_jar_stays_with_remove_private_classes(test):
+    analysis_test(
+        name = test.name,
+        impl = _associate_compile_jar_stays_,
         target = _arrange(test),
         config_settings = {
             "//command_line_option:extra_toolchains": [str(_REMOVE_PRIVATE_CLASSES_TOOLCHAIN)],
@@ -107,5 +158,6 @@ def associates_tests(name):
     suite(
         name,
         direct_dependencies = _test_associate_jars_are_direct_dependencies,
-        remove_private_classes = _test_associate_class_jar_is_direct_dependency_with_remove_private_classes,
+        remove_private_classes = _test_associate_compile_jar_stays_with_remove_private_classes,
+        treat_internal_as_private = _test_associate_class_jar_is_direct_dependency_with_treat_internal_as_private,
     )


### PR DESCRIPTION
… symbols

- Switch to using CLASS jars in associates only if 'internal' symbols are effectively removed. The 'experimental_remove_private_classes_in_abi_jars' alone strips only 'private' symbols and keeps 'internal' ones, so it is still possible to use COMPILE jars.