### PR TITLE
Default x_sam_conversions to 'indy', the Kotlin compiler's own SAM-co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ kt_jvm_library(
 
 ### Lambda Bytecode Generation
 
-Note: `kt_kotlinc_options` defaults `x_lambdas` and `x_sam_conversions` to `"class"`, which differs from Kotlin 2.x and Gradle's default of `"indy"` (invokedynamic). If you encounter issues with bytecode analysis tools expecting invokedynamic-based lambdas, configure these options:
+Note: `kt_kotlinc_options` defaults `x_sam_conversions` to `"indy"`, matching the Kotlin compiler's own default, but defaults `x_lambdas` to `"class"`, which differs from Kotlin 2.x and Gradle's default of `"indy"` (invokedynamic). If you encounter issues with bytecode analysis tools expecting invokedynamic-based lambdas, configure these options:
 
 ```python
 kt_kotlinc_options(

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -444,7 +444,7 @@ Define kotlin compiler options.
 | <a id="kt_kotlinc_options-x_render_internal_diagnostic_names"></a>x_render_internal_diagnostic_names |  Render the internal names of warnings and errors.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_report_all_warnings"></a>x_report_all_warnings |  Report all warnings even if errors are found.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_report_perf"></a>x_report_perf |  Report detailed performance statistics   | Boolean | optional |  `False`  |
-| <a id="kt_kotlinc_options-x_sam_conversions"></a>x_sam_conversions |  Change codegen behavior of SAM/functional interfaces. Defaults to "class" (anonymous inner classes), which differs from Kotlin 2.x/Gradle default of "indy" (invokedynamic). Set to "indy" for Gradle-compatible bytecode.   | String | optional |  `"class"`  |
+| <a id="kt_kotlinc_options-x_sam_conversions"></a>x_sam_conversions |  Change codegen behavior of SAM/functional interfaces. Defaults to "indy" (invokedynamic via LambdaMetafactory), matching Kotlin compiler's own default since 1.5. Set to "class" for legacy anonymous-class codegen.   | String | optional |  `"indy"`  |
 | <a id="kt_kotlinc_options-x_skip_prerelease_check"></a>x_skip_prerelease_check |  Suppress errors thrown when using pre-release classes.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_suppress_version_warnings"></a>x_suppress_version_warnings |  Suppress warnings about outdated, inconsistent, or experimental language or API versions.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_suppress_warning"></a>x_suppress_warning |  Suppress specific warnings globally   | List of strings | optional |  `[]`  |

--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -548,8 +548,8 @@ Migration to jvm_default:
     "x_sam_conversions": struct(
         flag = "-Xsam-conversions",
         args = dict(
-            default = "class",
-            doc = """Change codegen behavior of SAM/functional interfaces. Defaults to "class" (anonymous inner classes), which differs from Kotlin 2.x/Gradle default of "indy" (invokedynamic). Set to "indy" for Gradle-compatible bytecode.""",
+            default = "indy",
+            doc = """Change codegen behavior of SAM/functional interfaces. Defaults to "indy" (invokedynamic via LambdaMetafactory), matching Kotlin compiler's own default since 1.5. Set to "class" for legacy anonymous-class codegen.""",
             values = ["class", "indy"],
         ),
         type = attr.string,


### PR DESCRIPTION
…nversion mode

-Xsam-conversions=indy has been the Kotlin compiler default since 1.5; the previous 'class' default silently forced legacy anonymous-class codegen