### PR TITLE
Compile through the typed Build Tools API

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
@@ -8,7 +8,10 @@ kt_bootstrap_library(
     deps = [
         "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
         "//src/main/kotlin/io/bazel/kotlin/builder/toolchain",
+        "//src/main/kotlin/io/bazel/kotlin/compiler",
         "//src/main/kotlin/io/bazel/worker",
+        "//src/main/protobuf:kotlin_model_java_proto",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )
 

--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/Build.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/Build.kt
@@ -18,12 +18,35 @@
 package io.bazel.kotlin.builder.cmd
 
 import io.bazel.kotlin.builder.tasks.CompileKotlin
+import io.bazel.kotlin.builder.tasks.JvmTaskExecutor
 import io.bazel.kotlin.builder.tasks.KotlinBuilder
 import io.bazel.kotlin.builder.tasks.jvm.InternalCompilerPlugins
 import io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor
+import io.bazel.kotlin.builder.tasks.jvm.btapi.BtapiInvoker
+import io.bazel.kotlin.builder.tasks.jvm.btapi.BtapiTaskExecutor
+import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
+import io.bazel.kotlin.model.JvmCompilationTask
 import io.bazel.worker.Worker
 import kotlin.system.exitProcess
+
+private class DispatchingTaskExecutor(
+  private val legacyExecutor: KotlinJvmTaskExecutor,
+  btapiFactory: () -> BtapiTaskExecutor,
+) : JvmTaskExecutor {
+  private val btapiExecutor: BtapiTaskExecutor by lazy(btapiFactory)
+
+  override fun execute(
+    context: CompilationTaskContext,
+    task: JvmCompilationTask,
+  ) {
+    if (context.info.buildToolsApi) {
+      btapiExecutor.execute(context, task)
+    } else {
+      legacyExecutor.execute(context, task)
+    }
+  }
+}
 
 object Build {
   @JvmStatic
@@ -38,8 +61,11 @@ object Build {
             toolchain.kapt3Plugin,
             toolchain.jdepsGen,
           )
-        val compilerBuilder = KotlinToolchain.KotlincInvokerBuilder(toolchain)
-        val jvmTaskExecutor = KotlinJvmTaskExecutor(compilerBuilder, plugins)
+        val jvmTaskExecutor =
+          DispatchingTaskExecutor(
+            legacyExecutor = KotlinJvmTaskExecutor(toolchain, plugins),
+            btapiFactory = { BtapiTaskExecutor(BtapiInvoker(toolchain), plugins) },
+          )
         val builder = KotlinBuilder(jvmTaskExecutor)
         start(CompileKotlin(builder))
       }.run(::exitProcess)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -27,6 +27,7 @@ kt_bootstrap_library(
         "//src/main/kotlin/io/bazel/kotlin/builder/toolchain",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
+        "//src/main/kotlin/io/bazel/kotlin/compiler",
         "//src/main/kotlin/io/bazel/worker",
         "//src/main/protobuf:deps_java_proto",
         "//src/main/protobuf:kotlin_model_java_proto",

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -27,14 +27,11 @@ import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 import io.bazel.kotlin.model.JvmCompilationTask
 import java.io.BufferedInputStream
-import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.ObjectOutputStream
 import java.nio.file.Files.isDirectory
 import java.nio.file.Files.walk
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.Base64
 import java.util.stream.Collectors.toList
 import java.util.stream.Stream
 
@@ -83,126 +80,7 @@ fun JvmCompilationTask.baseArgs(overrides: Map<String, String> = emptyMap()): Co
       LANGUAGE_VERSION_ARG,
       overrides[LANGUAGE_VERSION_ARG] ?: info.toolchainInfo.common.languageVersion,
     ).flag("-jvm-target", info.toolchainInfo.jvm.jvmTarget)
-    .let { args ->
-      if (info.buildToolsApi && info.passthroughFlagsList.none { it.startsWith("-Xjdk-release") }) {
-        // Unless set explicitly, ensure the JDK API version corresponds to selected jvmTarget
-        args.flag("-Xjdk-release=${info.toolchainInfo.jvm.jvmTarget}")
-      } else {
-        args
-      }
-    }.flag("-module-name", info.moduleName)
-}
-
-internal fun JvmCompilationTask.plugins(
-  options: List<String>,
-  classpath: List<String>,
-): CompilationArgs =
-  CompilationArgs().apply {
-    classpath.forEach {
-      xFlag("plugin", it)
-    }
-
-    val optionTokens =
-      mapOf(
-        "{generatedClasses}" to directories.generatedClasses,
-        "{stubs}" to directories.stubs,
-        "{temp}" to directories.temp,
-        "{generatedSources}" to directories.generatedSources,
-        "{classpath}" to classpath.joinToString(File.pathSeparator),
-      )
-    options.forEach { opt ->
-      val formatted =
-        optionTokens.entries.fold(opt) { formatting, (token, value) ->
-          formatting.replace(token, value)
-        }
-      flag("-P", "plugin:$formatted")
-    }
-  }
-
-internal fun encodeMap(options: Map<String, String>): String {
-  val os = ByteArrayOutputStream()
-  val oos = ObjectOutputStream(os)
-
-  oos.writeInt(options.size)
-  for ((key, value) in options.entries) {
-    oos.writeUTF(key)
-    oos.writeUTF(value)
-  }
-
-  oos.flush()
-  return Base64
-    .getEncoder()
-    .encodeToString(os.toByteArray())
-}
-
-internal fun JvmCompilationTask.kaptArgs(
-  context: CompilationTaskContext,
-  plugins: InternalCompilerPlugins,
-  aptMode: String,
-): CompilationArgs {
-  // KAPT does not run javac's CLI argument parser and feeds options directly to javac.
-  // Javac reads option values via each option flag's canonical primaryName. That primaryName changed from
-  // "-source"/"-target" (JDK <= 11) to "--source"/"--target" (JDK >= 14).
-  // Pass both spelling variants, so that javac reads whichever is canonical on the running JDK and ignores the other.
-  val jvmTarget = info.toolchainInfo.jvm.jvmTarget
-  val javacArgs =
-    mapOf<String, String>(
-      "-target" to jvmTarget,
-      "--target" to jvmTarget,
-      "-source" to jvmTarget,
-      "--source" to jvmTarget,
-    )
-  return CompilationArgs().apply {
-    xFlag("plugin", plugins.kapt.jarPath)
-
-    val values =
-      arrayOf(
-        "sources" to listOf(directories.generatedJavaSources),
-        "classes" to listOf(directories.generatedClasses),
-        "stubs" to listOf(directories.stubs),
-        "incrementalData" to listOf(directories.incrementalData),
-        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
-        "correctErrorTypes" to listOf("false"),
-        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
-        "apclasspath" to inputs.processorpathsList,
-        "aptMode" to listOf(aptMode),
-      )
-    val version =
-      info.toolchainInfo.common.apiVersion
-        .toFloat()
-
-    when {
-      version < 1.5 -> {
-        base64Encode(
-          "-P",
-          *values + ("processors" to inputs.processorsList).asKeyToCommaList(),
-        ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
-      }
-
-      else -> {
-        repeatFlag(
-          "-P",
-          *values + ("processors" to inputs.processorsList),
-        ) { option, value ->
-          "plugin:${plugins.kapt.id}:$option=$value"
-        }
-      }
-    }
-    // Read kapt options from the plugin options
-    val optionPrefix = plugins.kapt.id + ":apoption="
-    val options =
-      (inputs.compilerPluginOptionsList + inputs.stubsPluginOptionsList)
-        .filter { o -> o.startsWith(optionPrefix) }
-        .map { o -> o.substring(optionPrefix.length).split(":", limit = 2) }
-        .map { kv -> kv[0] to listOf(kv[1]) }
-        .toTypedArray()
-
-    if (options.isNotEmpty()) {
-      base64Encode("-P", *options) { enc ->
-        "plugin:${plugins.kapt.id}:apoptions=$enc"
-      }
-    }
-  }
+    .flag("-module-name", info.moduleName)
 }
 
 internal fun JvmCompilationTask.runPlugins(
@@ -282,15 +160,7 @@ fun JvmCompilationTask.compileKotlin(
           options = inputs.compilerPluginOptionsList,
           classpath = inputs.compilerPluginClasspathList,
         )
-    ).let { compilationArgs ->
-      // Request '-verbose' execution for BTAPI compiler if tracing is enabled
-      val tracing = context.whenTracing { true } == true
-      if (info.buildToolsApi && tracing && "-verbose" !in compilationArgs.args) {
-        compilationArgs.flag("-verbose")
-      } else {
-        compilationArgs
-      }
-    }.list()
+    ).list()
       .let {
         context.whenTracing {
           context.printLines("compileKotlin arguments:\n", it)
@@ -323,10 +193,3 @@ fun JvmCompilationTask.compileKotlin(
       }
   }
 }
-
-/**
- * Helper function to convert a list of values into a single comma-separated string.
- * Used for KAPT plugin options in Kotlin versions < 1.5.
- */
-private fun Pair<String, List<String>>.asKeyToCommaList() =
-  first to listOf(second.joinToString(","))

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -29,7 +29,7 @@ import io.bazel.kotlin.model.JvmCompilationTask
 const val X_FRIENDS_PATH_SEPARATOR = ","
 
 class KotlinJvmTaskExecutor(
-  private val compilerBuilder: KotlinToolchain.KotlincInvokerBuilder,
+  private val toolchain: KotlinToolchain,
   private val plugins: InternalCompilerPlugins,
 ) : JvmTaskExecutor {
   private fun combine(
@@ -56,7 +56,7 @@ class KotlinJvmTaskExecutor(
     context: CompilationTaskContext,
     task: JvmCompilationTask,
   ) {
-    val compiler = compilerBuilder.build(context.info.buildToolsApi)
+    val compiler = KotlinToolchain.KotlincInvoker(toolchain)
 
     val preprocessedTask =
       task

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/PluginArgs.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/PluginArgs.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Assembles kotlinc compiler-plugin arguments (-Xplugin / -P) from the JvmCompilationTask
+// protocol buffer. These describe kotlinc's plugin CLI contract, which every compilation path
+// uses; the strings produced here are identical regardless of how the compiler is invoked.
+package io.bazel.kotlin.builder.tasks.jvm
+
+import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
+import io.bazel.kotlin.model.JvmCompilationTask
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.ObjectOutputStream
+import java.util.Base64
+
+internal fun JvmCompilationTask.plugins(
+  options: List<String>,
+  classpath: List<String>,
+): CompilationArgs =
+  CompilationArgs().apply {
+    classpath.forEach {
+      xFlag("plugin", it)
+    }
+
+    val optionTokens =
+      mapOf(
+        "{generatedClasses}" to directories.generatedClasses,
+        "{stubs}" to directories.stubs,
+        "{temp}" to directories.temp,
+        "{generatedSources}" to directories.generatedSources,
+        "{classpath}" to classpath.joinToString(File.pathSeparator),
+      )
+    options.forEach { opt ->
+      val formatted =
+        optionTokens.entries.fold(opt) { formatting, (token, value) ->
+          formatting.replace(token, value)
+        }
+      flag("-P", "plugin:$formatted")
+    }
+  }
+
+internal fun encodeMap(options: Map<String, String>): String {
+  val os = ByteArrayOutputStream()
+  val oos = ObjectOutputStream(os)
+
+  oos.writeInt(options.size)
+  for ((key, value) in options.entries) {
+    oos.writeUTF(key)
+    oos.writeUTF(value)
+  }
+
+  oos.flush()
+  return Base64
+    .getEncoder()
+    .encodeToString(os.toByteArray())
+}
+
+internal fun JvmCompilationTask.kaptArgs(
+  context: CompilationTaskContext,
+  plugins: InternalCompilerPlugins,
+  aptMode: String,
+): CompilationArgs {
+  // KAPT does not run javac's CLI argument parser and feeds options directly to javac.
+  // Javac reads option values via each option flag's canonical primaryName. That primaryName changed from
+  // "-source"/"-target" (JDK <= 11) to "--source"/"--target" (JDK >= 14).
+  // Pass both spelling variants, so that javac reads whichever is canonical on the running JDK and ignores the other.
+  val jvmTarget = info.toolchainInfo.jvm.jvmTarget
+  val javacArgs =
+    mapOf<String, String>(
+      "-target" to jvmTarget,
+      "--target" to jvmTarget,
+      "-source" to jvmTarget,
+      "--source" to jvmTarget,
+    )
+  return CompilationArgs().apply {
+    xFlag("plugin", plugins.kapt.jarPath)
+
+    val values =
+      arrayOf(
+        "sources" to listOf(directories.generatedJavaSources),
+        "classes" to listOf(directories.generatedClasses),
+        "stubs" to listOf(directories.stubs),
+        "incrementalData" to listOf(directories.incrementalData),
+        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
+        "correctErrorTypes" to listOf("false"),
+        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
+        "apclasspath" to inputs.processorpathsList,
+        "aptMode" to listOf(aptMode),
+      )
+    val version =
+      info.toolchainInfo.common.apiVersion
+        .toFloat()
+
+    when {
+      version < 1.5 -> {
+        base64Encode(
+          "-P",
+          *values + ("processors" to inputs.processorsList).asKeyToCommaList(),
+        ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
+      }
+
+      else -> {
+        repeatFlag(
+          "-P",
+          *values + ("processors" to inputs.processorsList),
+        ) { option, value ->
+          "plugin:${plugins.kapt.id}:$option=$value"
+        }
+      }
+    }
+    // Read kapt options from the plugin options
+    val optionPrefix = plugins.kapt.id + ":apoption="
+    val options =
+      (inputs.compilerPluginOptionsList + inputs.stubsPluginOptionsList)
+        .filter { o -> o.startsWith(optionPrefix) }
+        .map { o -> o.substring(optionPrefix.length).split(":", limit = 2) }
+        .map { kv -> kv[0] to listOf(kv[1]) }
+        .toTypedArray()
+
+    if (options.isNotEmpty()) {
+      base64Encode("-P", *options) { enc ->
+        "plugin:${plugins.kapt.id}:apoptions=$enc"
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to convert a list of values into a single comma-separated string.
+ * Used for KAPT plugin options in Kotlin versions < 1.5.
+ */
+private fun Pair<String, List<String>>.asKeyToCommaList() =
+  first to listOf(second.joinToString(","))

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiInvoker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiInvoker.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm.btapi
+
+import io.bazel.kotlin.builder.toolchain.KotlinToolchain
+import io.bazel.kotlin.compiler.CompilationUnit
+import io.bazel.kotlin.compiler.CompilerConfiguration
+import io.bazel.kotlin.compiler.KotlinBtapiCompiler
+import java.io.PrintStream
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.reflect.Proxy
+import kotlin.reflect.jvm.javaMethod
+
+/**
+ * Invokes the typed Build Tools API compilation entry point inside the isolated compiler
+ * classloader.
+ */
+class BtapiInvoker(
+  toolchain: KotlinToolchain,
+) : KotlinBtapiCompiler {
+  private val btapiClassLoader: ClassLoader = toolchain.classLoader
+  private val compilerImpl: Any
+  private val execHandle: MethodHandle
+  private val compilationUnitDispatcher = Dispatcher(CompilationUnit::class.java)
+  private val configurationDispatcher = Dispatcher(CompilerConfiguration::class.java)
+
+  init {
+    val compilerClass = btapiClassLoader.loadClass("io.bazel.kotlin.compiler.BuildToolsAPICompiler")
+    val compilerInterface = KotlinBtapiCompiler::class.java.counterpart()
+
+    compilerImpl =
+      compilerInterface.cast(
+        compilerClass
+          .getConstructor(Array<String>::class.java)
+          .newInstance(toolchain.btapiRuntimeClasspath.map { it.path }.toTypedArray() as Any),
+      )
+
+    val execMethod = checkNotNull(KotlinBtapiCompiler::exec.javaMethod)
+    execHandle =
+      MethodHandles.lookup().unreflect(
+        compilerInterface.getMethod(
+          execMethod.name,
+          *execMethod.parameterTypes.map { it.counterpart() }.toTypedArray(),
+        ),
+      )
+  }
+
+  override fun exec(
+    errStream: PrintStream,
+    compilationUnit: CompilationUnit,
+    configuration: CompilerConfiguration,
+  ): Int =
+    execHandle.invoke(
+      compilerImpl,
+      errStream,
+      compilationUnitDispatcher.applyTo(compilationUnit),
+      configurationDispatcher.applyTo(configuration),
+    ) as Int
+
+  /**
+   * The class's counterpart defined by the BTA implementation classloader
+   */
+  private fun Class<*>.counterpart(): Class<*> =
+    if (classLoader === KotlinBtapiCompiler::class.java.classLoader) {
+      btapiClassLoader.loadClass(name)
+    } else {
+      this
+    }
+
+  /**
+   * Dispatches calls from BTA-implementation side to worker-side data structures
+   */
+  private inner class Dispatcher(
+    contractInterface: Class<*>,
+  ) {
+    private val counterpartInterfaces = arrayOf(contractInterface.counterpart())
+    private val handles: Map<String, MethodHandle> =
+      buildMap {
+        val lookup = MethodHandles.lookup()
+        // Besides the contract's own methods, for completeness route also standard Object methods (equals/hashCode/toString)
+        for (method in contractInterface.methods + Any::class.java.methods) {
+          put(method.name, lookup.unreflect(method))
+        }
+      }
+
+    fun applyTo(instance: Any): Any =
+      Proxy.newProxyInstance(btapiClassLoader, counterpartInterfaces) { _, method, args ->
+        handles.getValue(method.name).invokeWithArguments(instance, *(args ?: emptyArray()))
+      }
+  }
+}

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm.btapi
+
+import com.google.devtools.build.lib.view.proto.Deps
+import io.bazel.kotlin.builder.tasks.JvmTaskExecutor
+import io.bazel.kotlin.builder.tasks.jvm.CompilationArgs
+import io.bazel.kotlin.builder.tasks.jvm.InternalCompilerPlugins
+import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.emptyJdeps
+import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.writeJdeps
+import io.bazel.kotlin.builder.tasks.jvm.createAbiJar
+import io.bazel.kotlin.builder.tasks.jvm.createCoverageInstrumentedJar
+import io.bazel.kotlin.builder.tasks.jvm.createGeneratedClassJar
+import io.bazel.kotlin.builder.tasks.jvm.createGeneratedJavaSrcJar
+import io.bazel.kotlin.builder.tasks.jvm.createGeneratedKspKotlinSrcJar
+import io.bazel.kotlin.builder.tasks.jvm.createGeneratedStubJar
+import io.bazel.kotlin.builder.tasks.jvm.createOutputJar
+import io.bazel.kotlin.builder.tasks.jvm.createdGeneratedKspClassesJar
+import io.bazel.kotlin.builder.tasks.jvm.expandWithGeneratedSources
+import io.bazel.kotlin.builder.tasks.jvm.kaptArgs
+import io.bazel.kotlin.builder.tasks.jvm.plugins
+import io.bazel.kotlin.builder.tasks.jvm.preProcessingSteps
+import io.bazel.kotlin.builder.toolchain.CompilationStatusException
+import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
+import io.bazel.kotlin.compiler.CompilationUnit
+import io.bazel.kotlin.compiler.CompilerConfiguration
+import io.bazel.kotlin.model.JvmCompilationTask
+import java.io.BufferedInputStream
+import java.io.PrintStream
+import java.nio.file.Paths
+
+/**
+ * Executes JVM compilation tasks through the typed Build Tools API path.
+ */
+class BtapiTaskExecutor(
+  private val invoker: BtapiInvoker,
+  private val plugins: InternalCompilerPlugins,
+) : JvmTaskExecutor {
+  override fun execute(
+    context: CompilationTaskContext,
+    task: JvmCompilationTask,
+  ) {
+    val preprocessedTask =
+      task
+        .preProcessingSteps(context)
+        .runKaptIfNeeded(context)
+
+    context.execute("compile classes") {
+      preprocessedTask.apply {
+        val outputLines =
+          try {
+            context.execute("kotlinc") {
+              if (compileKotlin) {
+                runKotlinCompiler(context)
+              } else {
+                if (outputs.jdeps.isNotEmpty()) {
+                  writeJdeps(outputs.jdeps, emptyJdeps(info.label))
+                }
+                emptyList()
+              }
+            } to null
+          } catch (e: CompilationStatusException) {
+            e.lines to e
+          }
+
+        outputLines.first.apply(context::printCompilerOutput)
+        outputLines.second?.let { throw it }
+
+        if (outputs.jar.isNotEmpty()) {
+          if (instrumentCoverage) {
+            context.execute("create instrumented jar", ::createCoverageInstrumentedJar)
+          } else {
+            context.execute("create jar", ::createOutputJar)
+          }
+        }
+        if (outputs.abijar.isNotEmpty()) {
+          context.execute("create abi jar", ::createAbiJar)
+        }
+        if (outputs.generatedJavaSrcJar.isNotEmpty()) {
+          context.execute("creating KAPT generated Java source jar", ::createGeneratedJavaSrcJar)
+        }
+        if (outputs.generatedJavaStubJar.isNotEmpty()) {
+          context.execute("creating KAPT generated Kotlin stubs jar", ::createGeneratedStubJar)
+        }
+        if (outputs.generatedClassJar.isNotEmpty()) {
+          context.execute("creating KAPT generated stub class jar", ::createGeneratedClassJar)
+        }
+        if (outputs.generatedKspSrcJar.isNotEmpty()) {
+          context.execute("creating KSP generated src jar", ::createGeneratedKspKotlinSrcJar)
+        }
+        if (outputs.generatedKspClassesJar.isNotEmpty()) {
+          context.execute("creating KSP generated classes jar", ::createdGeneratedKspClassesJar)
+        }
+      }
+    }
+  }
+
+  /**
+   * The KAPT stubs-and-apt pre-pass, followed by re-expanding the task with the generated sources.
+   */
+  private fun JvmCompilationTask.runKaptIfNeeded(
+    context: CompilationTaskContext,
+  ): JvmCompilationTask {
+    if (
+      (inputs.processorsList.isEmpty() && inputs.stubsPluginClasspathList.isEmpty()) ||
+      inputs.kotlinSourcesList.isEmpty()
+    ) {
+      return this
+    }
+    // KSP is handled externally in Starlark, only KAPT runs through the builder
+    if (outputs.generatedClassJar.isNullOrEmpty()) {
+      return this
+    }
+    return context.execute("kapt (${inputs.processorsList.joinToString(", ")})") {
+      val arguments =
+        plugins(
+          options = inputs.stubsPluginOptionsList.filterNot { o -> o.startsWith(plugins.kapt.id) },
+          classpath = inputs.stubsPluginClasspathList,
+        ).append(kaptArgs(context, plugins, "stubsAndApt"))
+          .list()
+      context
+        .executeCompilerTask(
+          { out -> invokeCompiler(context, arguments, directories.generatedClasses, out) },
+          printOnSuccess = context.whenTracing { true } == true,
+        ).let { outputLines ->
+          context.whenTracing {
+            printLines("kapt output", outputLines)
+          }
+          expandWithGeneratedSources()
+        }
+    }
+  }
+
+  private fun JvmCompilationTask.runKotlinCompiler(context: CompilationTaskContext): List<String> {
+    val arguments =
+      CompilationArgs()
+        .given(outputs.jdeps)
+        .notEmpty {
+          plugin(plugins.jdeps) {
+            flag("output", outputs.jdeps)
+            flag("target_label", info.label)
+            inputs.directDependenciesList.forEach {
+              flag("direct_dependencies", it)
+            }
+            inputs.classpathList.forEach {
+              flag("full_classpath", it)
+            }
+            flag("strict_kotlin_deps", info.strictKotlinDeps)
+          }
+        }.given(outputs.abijar)
+        .notEmpty {
+          plugin(plugins.jvmAbiGen) {
+            flag("outputDir", directories.abiClasses)
+            if (info.treatInternalAsPrivateInAbiJar) {
+              flag("treatInternalAsPrivate", "true")
+            }
+            if (info.removePrivateClassesInAbiJar) {
+              flag("removePrivateClasses", "true")
+            }
+            if (info.removeDebugInfo) {
+              flag("removeDebugInfo", "true")
+            }
+            if (info.preserveDeclarationOrder) {
+              flag("preserveDeclarationOrder", "true")
+            }
+            if (info.removeDataClassCopyIfConstructorIsPrivate) {
+              flag("removeDataClassCopyIfConstructorIsPrivate", "true")
+            }
+          }
+          given(outputs.jar).empty {
+            plugin(plugins.skipCodeGen)
+          }
+        }.values(info.passthroughFlagsList)
+        .append(
+          plugins(
+            options = inputs.compilerPluginOptionsList,
+            classpath = inputs.compilerPluginClasspathList,
+          ),
+        ).list()
+
+    context.whenTracing {
+      context.printLines("Kotlin Compiler arguments:\n", arguments)
+    }
+    return context.executeCompilerTask(
+      { out -> invokeCompiler(context, arguments, directories.classes, out) },
+      printOnFail = false,
+    )
+  }
+
+  private class TaskCompilationUnit(
+    override val sources: List<String>,
+    override val classpath: List<String>,
+    override val friendPaths: List<String>,
+    override val destination: String,
+  ) : CompilationUnit
+
+  private class TaskCompilerConfiguration(
+    override val moduleName: String,
+    override val jvmTarget: String,
+    override val apiVersion: String,
+    override val languageVersion: String,
+    override val passthroughArguments: List<String>,
+    override val verbose: Boolean,
+  ) : CompilerConfiguration
+
+  private fun JvmCompilationTask.invokeCompiler(
+    context: CompilationTaskContext,
+    arguments: List<String>,
+    destination: String,
+    out: PrintStream,
+  ): Int =
+    invoker.exec(
+      errStream = out,
+      compilationUnit =
+        TaskCompilationUnit(
+          sources = inputs.javaSourcesList + inputs.kotlinSourcesList,
+          classpath = computeClasspath() + directories.generatedClasses,
+          friendPaths = info.friendPathsList,
+          destination = destination,
+        ),
+      configuration =
+        TaskCompilerConfiguration(
+          moduleName = info.moduleName,
+          jvmTarget = info.toolchainInfo.jvm.jvmTarget,
+          apiVersion = info.toolchainInfo.common.apiVersion,
+          languageVersion = info.toolchainInfo.common.languageVersion,
+          passthroughArguments = arguments,
+          verbose = context.whenTracing { true } == true,
+        ),
+    )
+
+  /**
+   * The compile classpath, honoring the jdeps-based reduced classpath mode. Mirrors the legacy
+   * baseArgs classpath computation so both paths compile against the same entries.
+   */
+  private fun JvmCompilationTask.computeClasspath(): List<String> =
+    when (info.reducedClasspathMode) {
+      "KOTLINBUILDER_REDUCED" -> {
+        val transitiveDepsForCompile = mutableSetOf<String>()
+        inputs.depsArtifactsList.forEach { jdepsPath ->
+          BufferedInputStream(Paths.get(jdepsPath).toFile().inputStream()).use {
+            val deps = Deps.Dependencies.parseFrom(it)
+            deps.dependencyList.forEach { dep ->
+              if (dep.kind == Deps.Dependency.Kind.EXPLICIT) {
+                transitiveDepsForCompile.add(dep.path)
+              }
+            }
+          }
+        }
+        inputs.directDependenciesList + transitiveDepsForCompile
+      }
+
+      else -> {
+        inputs.classpathList
+      }
+    }
+}

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -30,6 +30,13 @@ class KotlinToolchain private constructor(
   val jvmAbiGen: CompilerPlugin,
   val skipCodeGen: CompilerPlugin,
   val jdepsGen: CompilerPlugin,
+  /**
+   * The jars from which the Build Tools API compiler assembles its runtime classloader: the
+   * Build Tools implementation, the daemon client, the compiler and the kotlinx-serialization
+   * runtime. The Kotlin standard library resolves through the compiler jar's manifest
+   * Class-Path, like in [classLoader].
+   */
+  val btapiRuntimeClasspath: List<File>,
 ) {
   companion object {
     private val JVM_ABI_PLUGIN by lazy {
@@ -162,6 +169,15 @@ class KotlinToolchain private constructor(
           kotlinxSerializationJson,
           kotlinxSerializationJsonJvm,
         ),
+        btapiRuntimeClasspath =
+          listOf(
+            buildTools,
+            kotlinDaemonClient,
+            kotlinc,
+            kotlinxSerializationCoreJvm,
+            kotlinxSerializationJson,
+            kotlinxSerializationJsonJvm,
+          ),
         jvmAbiGen =
           CompilerPlugin(
             jvmAbiGenFile.path,
@@ -197,9 +213,9 @@ class KotlinToolchain private constructor(
     val id: String,
   )
 
-  open class KotlincInvoker internal constructor(
+  open class KotlincInvoker(
     toolchain: KotlinToolchain,
-    clazz: String,
+    clazz: String = "io.bazel.kotlin.compiler.BazelK2JVMCompiler",
   ) {
     private val compiler: Any
     private val execHandle: MethodHandle
@@ -233,20 +249,6 @@ class KotlinToolchain private constructor(
     ): Int {
       val exitCode = execHandle.invoke(compiler, out, args, sources, destination)
       return getCodeHandle.invoke(exitCode) as Int
-    }
-  }
-
-  class KotlincInvokerBuilder(
-    private val toolchain: KotlinToolchain,
-  ) {
-    fun build(useExperimentalBuildToolsAPI: Boolean): KotlincInvoker {
-      val clazz =
-        if (useExperimentalBuildToolsAPI) {
-          "io.bazel.kotlin.compiler.BuildToolsAPICompiler"
-        } else {
-          "io.bazel.kotlin.compiler.BazelK2JVMCompiler"
-        }
-      return KotlincInvoker(toolchain = toolchain, clazz = clazz)
     }
   }
 }

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
@@ -19,62 +19,184 @@ import org.jetbrains.kotlin.buildtools.api.CompilationResult
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
+import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
+import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.JvmTarget
 import org.jetbrains.kotlin.buildtools.api.getToolchain
 import org.jetbrains.kotlin.buildtools.api.jvm.JvmPlatformToolchain
-import org.jetbrains.kotlin.cli.common.ExitCode
+import java.io.File
 import java.io.PrintStream
+import java.net.URLClassLoader
 import java.nio.file.Paths
+import org.jetbrains.kotlin.buildtools.api.arguments.enums.KotlinVersion as BtapiKotlinVersion
 
 @Suppress("unused")
-class BuildToolsAPICompiler : KotlinCompiler {
-  @OptIn(ExperimentalBuildToolsApi::class)
+@OptIn(ExperimentalBuildToolsApi::class)
+class BuildToolsAPICompiler(
+  /**
+   * Build Tools implementation jars with required dependencies
+   */
+  btImplClasspath: Array<String>,
+) : KotlinBtapiCompiler {
+  /** The state derived from the runtime classloader, initialized once and reused by every [exec]. */
+  private class BtImplRuntime(
+    val kotlinToolchains: KotlinToolchains,
+    val exitCodes: Map<CompilationResult, Int>,
+  )
+
+  private val runtime by lazy {
+    val classLoader =
+      URLClassLoader(
+        btImplClasspath.map { File(it).toURI().toURL() }.toTypedArray(),
+        SharedApiClassesClassLoader(), // allows only BuildTools API classes from the parent loader
+      )
+    BtImplRuntime(
+      kotlinToolchains = KotlinToolchains.loadImplementation(classLoader),
+      exitCodes = exitCodesFrom(classLoader),
+    )
+  }
+
+  /**
+   * CompilationResult to int exit codes mapping
+   */
+  private fun exitCodesFrom(classLoader: ClassLoader): Map<CompilationResult, Int> {
+    val exitCodeClass = classLoader.loadClass("org.jetbrains.kotlin.cli.common.ExitCode")
+    val getCode = exitCodeClass.getMethod("getCode")
+    val constantsByName = exitCodeClass.enumConstants.associateBy { (it as Enum<*>).name }
+
+    fun codeOf(name: String): Int {
+      val constant =
+        checkNotNull(constantsByName[name]) {
+          "the compiler runtime's ExitCode declares no constant named $name"
+        }
+      return getCode.invoke(constant) as Int
+    }
+
+    return mapOf(
+      CompilationResult.COMPILATION_SUCCESS to codeOf("OK"),
+      CompilationResult.COMPILATION_ERROR to codeOf("COMPILATION_ERROR"),
+      CompilationResult.COMPILATION_OOM_ERROR to codeOf("OOM_ERROR"),
+      CompilationResult.COMPILER_INTERNAL_ERROR to codeOf("INTERNAL_ERROR"),
+    )
+  }
+
+  @OptIn(ExperimentalBuildToolsApi::class, ExperimentalCompilerArgument::class)
   override fun exec(
     errStream: PrintStream,
-    args: Array<String>,
-    sources: Array<String>,
-    destination: String,
-  ): ExitCode {
+    compilationUnit: CompilationUnit,
+    configuration: CompilerConfiguration,
+  ): Int {
     System.setProperty("zip.handler.uses.crc.instead.of.timestamp", "true")
 
-    val kotlinToolchains = KotlinToolchains.loadImplementation(this.javaClass.classLoader!!)
-
     val operationBuilder =
-      kotlinToolchains
+      runtime.kotlinToolchains
         .getToolchain<JvmPlatformToolchain>()
         .jvmCompilationOperationBuilder(
-          sources.map { Paths.get(it) },
-          Paths.get(destination),
+          compilationUnit.sources.map { Paths.get(it) },
+          Paths.get(compilationUnit.destination),
         )
 
-    // Apply raw CLI arguments - this parses the args and sets all compiler options
-    // TODO: we can use actual typed API after we get rid of BazelK2JVMCompiler and use BTAPI exclusively
-    operationBuilder.compilerArguments.applyArgumentStrings(args.toList())
+    val args = operationBuilder.compilerArguments
 
-    // The rules assemble the complete compile classpath themselves, including the Kotlin
-    // stdlib/reflect, so the compiler must not auto-append them from its own
-    // install location: that extra classpath root shadows explicitly declared dependencies.
-    // Applied after the user arguments so they cannot re-enable the Kotlin home discovery.
-    operationBuilder.compilerArguments[JvmCompilerArguments.NO_STDLIB] = true
-    operationBuilder.compilerArguments[JvmCompilerArguments.NO_REFLECT] = true
+    // 1. User pass-through flags and compiler plugin arguments (resets the builder; must be first).
+    val passthroughArguments = configuration.passthroughArguments
+    if (passthroughArguments.isNotEmpty()) {
+      args.applyArgumentStrings(passthroughArguments)
+    }
 
-    // Execute the compilation
+    // 2. Toolchain defaults -- only for options the user did not set, so user flags win.
+    var effectiveJvmTarget = args[JvmCompilerArguments.JVM_TARGET]
+    if (effectiveJvmTarget == null) {
+      effectiveJvmTarget = requireJvmTarget(configuration.jvmTarget)
+      args[JvmCompilerArguments.JVM_TARGET] = effectiveJvmTarget
+    }
+    // Unless set explicitly, ensure the JDK API version corresponds to the selected jvm target.
+    if (args[JvmCompilerArguments.X_JDK_RELEASE] == null) {
+      val jdkRelease = jdkReleaseFor(effectiveJvmTarget)
+      if (jdkRelease != null) {
+        args[JvmCompilerArguments.X_JDK_RELEASE] = jdkRelease
+      }
+    }
+    if (args[CommonCompilerArguments.API_VERSION] == null) {
+      args[CommonCompilerArguments.API_VERSION] =
+        requireKotlinVersion(version = configuration.apiVersion, fieldName = "kotlin_api_version")
+    }
+    if (args[CommonCompilerArguments.LANGUAGE_VERSION] == null) {
+      args[CommonCompilerArguments.LANGUAGE_VERSION] =
+        requireKotlinVersion(
+          version = configuration.languageVersion,
+          fieldName = "kotlin_language_version",
+        )
+    }
+
+    // 3. Rules-managed settings -- applied last so user flags cannot clobber them.
+    // The rules assemble the complete classpath explicitly (including the Kotlin stdlib),
+    // so the compiler must not try to locate a Kotlin home distribution to auto-append stdlib/reflect.
+    args[JvmCompilerArguments.NO_STDLIB] = true
+    args[JvmCompilerArguments.NO_REFLECT] = true
+
+    args[JvmCompilerArguments.MODULE_NAME] = configuration.moduleName
+    if (compilationUnit.classpath.isNotEmpty()) {
+      args[JvmCompilerArguments.CLASSPATH] =
+        compilationUnit.classpath.map { Paths.get(File(it).absolutePath) }
+    }
+    if (compilationUnit.friendPaths.isNotEmpty()) {
+      args[JvmCompilerArguments.X_FRIEND_PATHS] =
+        compilationUnit.friendPaths.map { Paths.get(File(it).absolutePath) }
+    }
+
     val result =
-      kotlinToolchains.createBuildSession().use { session ->
+      runtime.kotlinToolchains.createBuildSession().use { session ->
         session.executeOperation(
           operationBuilder.build(),
-          logger = createLogger(errStream, verbose = "-verbose" in args),
+          logger = createLogger(errStream, verbose = configuration.verbose),
         )
       }
 
-    // BTAPI returns a different type than K2JVMCompiler (CompilationResult vs ExitCode).
-    return when (result) {
-      CompilationResult.COMPILATION_SUCCESS -> ExitCode.OK
-      CompilationResult.COMPILATION_ERROR -> ExitCode.COMPILATION_ERROR
-      CompilationResult.COMPILATION_OOM_ERROR -> ExitCode.OOM_ERROR
-      CompilationResult.COMPILER_INTERNAL_ERROR -> ExitCode.INTERNAL_ERROR
-    }
+    return runtime.exitCodes.getValue(result)
   }
+
+  private fun requireJvmTarget(target: String): JvmTarget {
+    val normalizedTarget = normalizeJvmTarget(target.trim())
+    return JvmTarget.entries.firstOrNull { it.stringValue == normalizedTarget }
+      ?: throw IllegalArgumentException(
+        "Unsupported kotlin_jvm_target '$target'. Supported values: " +
+          JvmTarget.entries.joinToString(", ") { it.stringValue },
+      )
+  }
+
+  private fun normalizeJvmTarget(target: String): String =
+    when (target) {
+      "6" -> "1.6"
+      "8" -> "1.8"
+      else -> target
+    }
+
+  /**
+   * The -Xjdk-release matching the given JVM target -- their string forms coincide (e.g. "1.8" /
+   * "17"), and JdkRelease's values are a superset of JvmTarget's, so this resolves for every valid
+   * target. Returns null only if a future Build Tools API splits the two enums; callers treat that
+   * as "no default" (the user can set -Xjdk-release explicitly) rather than a failure.
+   */
+  @OptIn(ExperimentalCompilerArgument::class)
+  private fun jdkReleaseFor(jvmTarget: JvmTarget): JdkRelease? =
+    JdkRelease.entries.firstOrNull { it.stringValue == jvmTarget.stringValue }
+
+  /**
+   * Parse a Kotlin version string to the typed enum and fail fast for unsupported values.
+   */
+  private fun requireKotlinVersion(
+    version: String,
+    fieldName: String,
+  ): BtapiKotlinVersion =
+    BtapiKotlinVersion.entries.firstOrNull { it.stringValue == version.trim() }
+      ?: throw IllegalArgumentException(
+        "Unsupported $fieldName '$version'. Supported values: " +
+          BtapiKotlinVersion.entries.joinToString(", ") { it.stringValue },
+      )
 
   private fun createLogger(
     out: PrintStream,

--- a/src/main/kotlin/io/bazel/kotlin/compiler/KotlinBtapiCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/KotlinBtapiCompiler.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.bazel.kotlin.compiler
+
+import java.io.PrintStream
+
+/** What to compile and where the output goes. */
+interface CompilationUnit {
+  val sources: List<String>
+  val classpath: List<String>
+  val friendPaths: List<String>
+  val destination: String
+}
+
+/** The compiler configuration the rules manage for the compilation. */
+interface CompilerConfiguration {
+  val moduleName: String
+  val jvmTarget: String
+  val apiVersion: String
+  val languageVersion: String
+
+  /** The user's pass-through compiler flags. */
+  val passthroughArguments: List<String>
+  val verbose: Boolean
+}
+
+/**
+ * The typed Build Tools API compilation contract between the worker and the compiler classloader.
+ * Provides structured API to invoke compiler as an in-process utility.
+ */
+interface KotlinBtapiCompiler {
+  fun exec(
+    errStream: PrintStream,
+    compilationUnit: CompilationUnit,
+    configuration: CompilerConfiguration,
+  ): Int
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -22,12 +22,15 @@ import io.bazel.kotlin.builder.Deps.AnnotationProcessor;
 import io.bazel.kotlin.builder.Deps.Dep;
 import io.bazel.kotlin.builder.tasks.jvm.InternalCompilerPlugins;
 import io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor;
+import io.bazel.kotlin.builder.tasks.jvm.btapi.BtapiInvoker;
+import io.bazel.kotlin.builder.tasks.jvm.btapi.BtapiTaskExecutor;
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext;
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain;
 import io.bazel.kotlin.model.CompilationTaskInfo;
 import io.bazel.kotlin.model.JvmCompilationTask;
 import io.bazel.kotlin.model.KotlinToolchainInfo;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.function.BiConsumer;
@@ -60,6 +63,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
 
     private final TaskBuilder taskBuilderInstance = new TaskBuilder();
     private static KotlinJvmTaskExecutor jvmTaskExecutor;
+    private static BtapiTaskExecutor btapiTaskExecutor;
 
     @Override
     void setupForNext(CompilationTaskInfo.Builder taskInfo) {
@@ -92,7 +96,17 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
 
     @SafeVarargs
     public final Dep runCompileTask(Consumer<TaskBuilder>... setup) {
-        return executeTask(jvmTaskExecutor()::execute, setup);
+        // Mirror the worker's dispatch: tasks flagged for the Build Tools API run through the
+        // typed executor, everything else through the legacy executor.
+        return executeTask(
+                (context, task) -> {
+                    if (task.getInfo().getBuildToolsApi()) {
+                        btapiTaskExecutor().execute(context, task);
+                    } else {
+                        jvmTaskExecutor().execute(context, task);
+                    }
+                },
+                setup);
     }
 
     private static KotlinJvmTaskExecutor jvmTaskExecutor() {
@@ -104,11 +118,36 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                     toolchain.getKapt3Plugin(),
                     toolchain.getJdepsGen()
             );
-            KotlinToolchain.KotlincInvokerBuilder compilerBuilder =
-                    new KotlinToolchain.KotlincInvokerBuilder(toolchain);
-            jvmTaskExecutor = new KotlinJvmTaskExecutor(compilerBuilder, plugins);
+            jvmTaskExecutor = new KotlinJvmTaskExecutor(toolchain, plugins);
         }
         return jvmTaskExecutor;
+    }
+
+    private static BtapiTaskExecutor btapiTaskExecutor() {
+        if (btapiTaskExecutor == null) {
+            KotlinToolchain toolchain = toolchainForTest();
+            InternalCompilerPlugins plugins = new InternalCompilerPlugins(
+                    toolchain.getJvmAbiGen(),
+                    toolchain.getSkipCodeGen(),
+                    toolchain.getKapt3Plugin(),
+                    toolchain.getJdepsGen()
+            );
+            btapiTaskExecutor = new BtapiTaskExecutor(new BtapiInvoker(toolchain), plugins);
+        }
+        return btapiTaskExecutor;
+    }
+
+    /**
+     * The class-file major version of a compiled class, read from the CLASSES output directory.
+     */
+    public final int classFileMajorVersion(String relativeClassPath) {
+        try {
+            byte[] bytes = java.nio.file.Files.readAllBytes(
+                    directory(DirectoryType.CLASSES).resolve(relativeClassPath));
+            return ((bytes[6] & 0xFF) << 8) | (bytes[7] & 0xFF);
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
     }
 
     private Dep executeTask(
@@ -271,6 +310,11 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
 
         public TaskBuilder useBuildToolsApi() {
             taskBuilder.getInfoBuilder().setBuildToolsApi(true);
+            return this;
+        }
+
+        public TaskBuilder addPassthroughFlags(String... flags) {
+            taskBuilder.getInfoBuilder().addAllPassthroughFlags(Arrays.asList(flags));
             return this;
         }
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderBuildTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderBuildTest.kt
@@ -107,7 +107,7 @@ class KotlinBuilderBuildTest {
         File(Deps.Dep.fromLabel("@kotlinx_serialization_json_jvm//file").singleCompileJar()),
       )
     return KotlinJvmTaskExecutor(
-      KotlinToolchain.KotlincInvokerBuilder(toolchain),
+      toolchain,
       InternalCompilerPlugins(
         toolchain.jvmAbiGen,
         toolchain.skipCodeGen,

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
@@ -95,7 +95,55 @@ public class KotlinBuilderJvmBtaTest {
                 lines -> assertThat(String.join("\n", lines)).contains("DoesNotExist"));
     }
 
-  @Test
+    @Test
+    public void testNoKotlinHomeResolutionWarnings() {
+        // The typed path passes -no-stdlib/-no-reflect: the rules assemble the complete
+        // classpath themselves, and a compiler runtime without a Kotlin home distribution
+        // (e.g. the embeddable family) would otherwise emit "Unable to find kotlin-stdlib.jar"
+        // warnings on every compile, failing compilations that enable -Werror.
+        ctx.runCompileTask(
+                c -> {
+                    c.useBuildToolsApi();
+                    c.compileKotlin();
+                    c.addSource("AClass.kt", "package something;" + "class AClass{}");
+                    c.outputJar();
+                    c.outputJdeps();
+                });
+        assertThat(String.join("\n", ctx.outLines())).doesNotContain("Unable to find");
+    }
+
+    @Test
+    public void testTypedArgumentsFollowToolchainJvmTarget() {
+        // The worker passes jvm_target as a typed Build Tools API argument (no CLI flattening);
+        // the produced bytecode must follow the toolchain's target (11 -> class file major 55).
+        ctx.runCompileTask(
+                c -> {
+                    c.useBuildToolsApi();
+                    c.compileKotlin();
+                    c.addSource("AClass.kt", "package something;" + "class AClass{}");
+                    c.outputJar();
+                    c.outputJdeps();
+                });
+        assertThat(ctx.classFileMajorVersion("something/AClass.class")).isEqualTo(55);
+    }
+
+    @Test
+    public void testPassthroughFlagsOverrideTypedToolchainDefaults() {
+        // User pass-through flags are applied before the typed defaults and must win: an explicit
+        // -jvm-target 17 (class file major 61) overrides the toolchain's jvm_target 11.
+        ctx.runCompileTask(
+                c -> {
+                    c.useBuildToolsApi();
+                    c.compileKotlin();
+                    c.addPassthroughFlags("-jvm-target", "17", "-Xjdk-release=17");
+                    c.addSource("AClass.kt", "package something;" + "class AClass{}");
+                    c.outputJar();
+                    c.outputJdeps();
+                });
+        assertThat(ctx.classFileMajorVersion("something/AClass.class")).isEqualTo(61);
+    }
+
+    @Test
     public void testJdkApiSurfaceLimitedToJvmTarget() {
         // The BTAPI implementation enforces compile-time JDK API version to correspond to the selected jvm_target via -Xjdk-release.
         ctx.runFailingCompileTaskAndValidateOutput(


### PR DESCRIPTION
The worker now invokes the Kotlin compiler through typed Build Tools API, replacing the implementation that parsed CLI flags. The legacy way to invoke compiler remains fully functional and is still the default.

- introduce KotlinBtapiCompiler, the typed contract between the worker and the Build Tools API implementation
- encapsulate all Build-Tools-API-specific worker code in the new tasks/jvm/btapi package (BtapiInvoker, BtapiTaskExecutor)