### PR TITLE
Make core/plugin bzl_library public for stardoc

### DIFF
--- a/src/main/starlark/core/plugin/BUILD.bazel
+++ b/src/main/starlark/core/plugin/BUILD.bazel
@@ -14,5 +14,5 @@ release_archive(
 bzl_library(
     name = "plugin",
     srcs = glob(["*.bzl"]),
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
The downstream module documents its wrappers via stardoc and loads these modules transitively.
We align the visibility with the already existing public bzl_library.