### PR TITLE
Pass compiler plugins as a single typed JSON payload

### DIFF
--- a/examples/path_mapping/.bazelrc
+++ b/examples/path_mapping/.bazelrc
@@ -5,3 +5,18 @@ build --worker_max_instances=1
 build --worker_quit_after_build
 build --profile=/tmp/profile.gz
 build --experimental_worker_max_multiplex_instances=KotlinCompile=5
+
+# Engage path mapping: //:kotlin_toolchain declares support for it (supports_path_mapping),
+# these flags actually activate it for the build. Workers run singleplex and sandboxed:
+# the multiplex worker does not resolve request paths against the request sandbox_dir yet,
+# so multiplex sandboxing fails to read its own flagfile under path mapping.
+# Linux/macOS only: path mapping requires a sandboxing-capable strategy, and Windows has
+# none - a mapped spawn there fails with "cannot be executed with any of the available
+# strategies", so on Windows the example builds unmapped.
+common --enable_platform_specific_config
+build:linux --experimental_output_paths=strip
+build:linux --worker_sandboxing
+build:linux --noworker_multiplex
+build:macos --experimental_output_paths=strip
+build:macos --worker_sandboxing
+build:macos --noworker_multiplex

--- a/examples/path_mapping/MODULE.bazel
+++ b/examples/path_mapping/MODULE.bazel
@@ -8,3 +8,8 @@ local_path_override(
 )
 
 bazel_dep(name = "bazel_features", version = "1.39.0")
+
+# The local toolchain declares path mapping support; without this registration the
+# rules_kotlin default toolchain (no path mapping) would win and the example would
+# silently build unmapped.
+register_toolchains("//:kotlin_toolchain")

--- a/examples/path_mapping/src/allopen/BUILD.bazel
+++ b/examples/path_mapping/src/allopen/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@rules_java//java:defs.bzl", "java_import")
+load("@rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+# Copy the allopen jar out of the external repository so the plugin classpath entry is a
+# derived artifact under bazel-out: path mapping only rewrites derived paths, so a source
+# jar served straight from the external repository could never detect a plugins payload
+# that bakes unmapped paths.
+genrule(
+    name = "allopen_compiler_plugin_jar",
+    srcs = ["@rules_kotlin//kotlin/compiler:allopen-compiler-plugin"],
+    outs = ["allopen-compiler-plugin.jar"],
+    cmd = "cp $< $@",
+)
+
+java_import(
+    name = "allopen_derived",
+    jars = [":allopen_compiler_plugin_jar"],
+)
+
+kt_compiler_plugin(
+    name = "open_for_testing_plugin",
+    compile_phase = True,
+    id = "org.jetbrains.kotlin.allopen",
+    options = {
+        "annotation": "pathmapping.allopen.OpenForTesting",
+    },
+    stubs_phase = True,
+    deps = [":allopen_derived"],
+)
+
+kt_jvm_library(
+    name = "open_for_testing",
+    srcs = ["OpenForTesting.kt"],
+)
+
+kt_jvm_library(
+    name = "user",
+    srcs = ["User.kt"],
+    plugins = [":open_for_testing_plugin"],
+    deps = [":open_for_testing"],
+)
+
+# Compiles only if the allopen plugin actually ran while compiling :user - without it,
+# User is final and subclassing fails. With path mapping engaged, a successful build
+# proves the worker loaded the plugin from the mapped classpath the payload carries.
+kt_jvm_library(
+    name = "user_is_open",
+    srcs = ["UserIsOpen.kt"],
+    deps = [":user"],
+)

--- a/examples/path_mapping/src/allopen/OpenForTesting.kt
+++ b/examples/path_mapping/src/allopen/OpenForTesting.kt
@@ -1,0 +1,3 @@
+package pathmapping.allopen
+
+annotation class OpenForTesting

--- a/examples/path_mapping/src/allopen/User.kt
+++ b/examples/path_mapping/src/allopen/User.kt
@@ -1,0 +1,6 @@
+package pathmapping.allopen
+
+@OpenForTesting
+class User(
+    val id: Int,
+)

--- a/examples/path_mapping/src/allopen/UserIsOpen.kt
+++ b/examples/path_mapping/src/allopen/UserIsOpen.kt
@@ -1,0 +1,4 @@
+package pathmapping.allopen
+
+// Compiles only when the allopen compiler plugin has opened User.
+class Subclass : User(1)

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -53,6 +53,10 @@ load(
     "//kotlin/internal/utils:utils.bzl",
     _utils = "utils",
 )
+load(
+    "//src/main/starlark/core/plugin:payload.bzl",
+    _plugin_payload = "plugin_payload",
+)
 
 # UTILITY ##############################################################################################################
 def find_java_toolchain(ctx, target):
@@ -178,29 +182,13 @@ def _resource_path_relative_to_root(resource):
 
     return resource.path
 
-def _format_compile_plugin_options(o):
-    """Format compiler option into id:value for cmd line."""
-    return [
-        "%s:%s" % (o.id, o.value),
-    ]
-
 def _new_plugins_from(targets):
     """Returns a struct containing the plugin metadata for the given targets.
 
     Args:
         targets: A list of targets.
     Returns:
-        A struct containing the plugins for the given targets in the format:
-        {
-            stubs_phase = {
-                classpath = depset,
-                options= List[KtCompilerPluginOption],
-            ),
-            compile = {
-                classpath = depset,
-                options = List[KtCompilerPluginOption],
-            },
-        }
+        A struct containing merged plugins and aggregate classpath/data.
     """
 
     all_plugins = {}
@@ -217,7 +205,7 @@ def _new_plugins_from(targets):
         all_plugins[plugin.id] = plugin
 
     if plugins_without_phase:
-        fail("has plugin without a phase defined: %s" % cfgs_without_plugin)
+        fail("has plugin without a phase defined: %s" % plugins_without_phase)
 
     all_plugin_cfgs = {}
     cfgs_without_plugin = []
@@ -232,28 +220,36 @@ def _new_plugins_from(targets):
     if cfgs_without_plugin:
         fail("has plugin configurations without corresponding plugins: %s" % cfgs_without_plugin)
 
-    return struct(
-        stubs_phase = _new_plugin_from(all_plugin_cfgs, [p for p in all_plugins.values() if p.stubs]),
-        compile_phase = _new_plugin_from(all_plugin_cfgs, [p for p in all_plugins.values() if p.compile]),
-    )
-
-def _new_plugin_from(all_cfgs, plugins_for_phase):
     classpath = []
     data = []
-    options = []
-    for p in plugins_for_phase:
-        classpath.append(p.classpath)
-        options.extend(p.options)
-        if p.id in all_cfgs:
-            cfg = p.merge_cfgs(p, all_cfgs[p.id])
-            classpath.append(cfg.classpath)
+    plugins = []
+    for p in all_plugins.values():
+        plugin_classpath = [p.classpath]
+        plugin_options = list(p.options)
+        if p.id in all_plugin_cfgs:
+            cfg = p.merge_cfgs(p, all_plugin_cfgs[p.id])
+            plugin_classpath.append(cfg.classpath)
             data.append(cfg.data)
-            options.extend(cfg.options)
+            plugin_options.extend(cfg.options)
+
+        phases = []
+        if p.compile:
+            phases.append("compile")
+        if p.stubs:
+            phases.append("stubs")
+
+        plugins.append(struct(
+            id = p.id,
+            phases = phases,
+            classpath = depset(transitive = plugin_classpath),
+            options = plugin_options,
+        ))
+        classpath.extend(plugin_classpath)
 
     return struct(
         classpath = depset(transitive = classpath),
         data = depset(transitive = data),
-        options = options,
+        plugins = plugins,
     )
 
 # INTERNAL ACTIONS #####################################################################################################
@@ -582,6 +578,10 @@ def _run_ksp_builder_actions(
         ksp_generated_src_jar = ksp_generated_java_srcjar,
     )
 
+# payload: the single args.add_all item, a struct(plugins = ...) carrying the list of compiler plugins
+def _plugins_payload_to_json(payload):
+    return _plugin_payload.plugins_payload_json(payload.plugins)
+
 def _run_kt_builder_action(
         ctx,
         mnemonic,
@@ -691,30 +691,14 @@ def _run_kt_builder_action(
         uniquify = True,
     )
 
+    # Using 'args.add_all' with a map_each callback instead of 'args.add' allows the json payload
+    # to be computed lazily during command line expansion, when the PathMapper, if any, is
+    # installed (e.g. with --experimental_output_paths=strip). This ensures the computed payload
+    # contains correctly mapped paths.
     args.add_all(
-        "--stubs_plugin_classpath",
-        plugins.stubs_phase.classpath,
-        omit_if_empty = True,
-    )
-
-    args.add_all(
-        "--stubs_plugin_options",
-        plugins.stubs_phase.options,
-        map_each = _format_compile_plugin_options,
-        omit_if_empty = True,
-    )
-
-    args.add_all(
-        "--compiler_plugin_classpath",
-        plugins.compile_phase.classpath,
-        omit_if_empty = True,
-    )
-
-    args.add_all(
-        "--compiler_plugin_options",
-        plugins.compile_phase.options,
-        map_each = _format_compile_plugin_options,
-        omit_if_empty = True,
+        "--plugins_payload",
+        [struct(plugins = plugins.plugins)],
+        map_each = _plugins_payload_to_json,
     )
 
     if not "kt_remove_debug_info_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_remove_debug_info_in_abi_jars == True:
@@ -739,8 +723,7 @@ def _run_kt_builder_action(
                 compile_deps.compile_jars,
                 transitive_runtime_jars,
                 deps_artifacts,
-                plugins.stubs_phase.classpath,
-                plugins.compile_phase.classpath,
+                plugins.classpath,
             ],
         ),
         tools = [

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -53,10 +53,7 @@ class KotlinBuilder(
       SOURCE_JARS("--source_jars"),
       PROCESSOR_PATH("--processorpath"),
       PROCESSORS("--processors"),
-      STUBS_PLUGIN_OPTIONS("--stubs_plugin_options"),
-      STUBS_PLUGIN_CLASS_PATH("--stubs_plugin_classpath"),
-      COMPILER_PLUGIN_OPTIONS("--compiler_plugin_options"),
-      COMPILER_PLUGIN_CLASS_PATH("--compiler_plugin_classpath"),
+      PLUGINS_PAYLOAD("--plugins_payload"),
       OUTPUT("--output"),
       RULE_KIND("--rule_kind"),
       MODULE_NAME("--kotlin_module_name"),
@@ -280,19 +277,35 @@ class KotlinBuilder(
         addAllProcessors(argMap.optional(KotlinBuilderFlags.PROCESSORS) ?: emptyList())
         addAllProcessorpaths(argMap.optional(KotlinBuilderFlags.PROCESSOR_PATH) ?: emptyList())
 
-        addAllStubsPluginOptions(
-          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_OPTIONS) ?: emptyList(),
-        )
-        addAllStubsPluginClasspath(
-          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_CLASS_PATH) ?: emptyList(),
-        )
+        val plugins =
+          argMap
+            .optional(KotlinBuilderFlags.PLUGINS_PAYLOAD)
+            ?.singleOrNull()
+            ?.let(PluginsPayloadParser::parse)
+            ?: emptyList()
+        addAllPlugins(plugins)
 
-        addAllCompilerPluginOptions(
-          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_OPTIONS) ?: emptyList(),
-        )
-        addAllCompilerPluginClasspath(
-          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_CLASS_PATH) ?: emptyList(),
-        )
+        // Expand the structured plugins into the per-phase fields the compilation paths consume.
+        // The expansion reproduces the exact strings the legacy per-phase worker flags used to
+        // carry, so the -Xplugin/-P arguments handed to kotlinc are unchanged.
+        for (plugin in plugins) {
+          val optionStrings =
+            plugin.optionsList.map { option ->
+              if (option.value.isEmpty()) {
+                "${plugin.id}:${option.key}"
+              } else {
+                "${plugin.id}:${option.key}=${option.value}"
+              }
+            }
+          if (JvmCompilationTask.Inputs.PluginPhase.PLUGIN_PHASE_STUBS in plugin.phasesList) {
+            addAllStubsPluginClasspath(plugin.classpathList)
+            addAllStubsPluginOptions(optionStrings)
+          }
+          if (JvmCompilationTask.Inputs.PluginPhase.PLUGIN_PHASE_COMPILE in plugin.phasesList) {
+            addAllCompilerPluginClasspath(plugin.classpathList)
+            addAllCompilerPluginOptions(optionStrings)
+          }
+        }
 
         argMap
           .optional(KotlinBuilderFlags.SOURCES)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadParser.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks
+
+import com.google.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.util.JsonFormat
+import io.bazel.kotlin.model.JvmCompilationTask
+
+object PluginsPayloadParser {
+  @JvmStatic
+  fun parse(json: String): List<JvmCompilationTask.Inputs.Plugin> {
+    val inputs = JvmCompilationTask.Inputs.newBuilder()
+    try {
+      JsonFormat.parser().ignoringUnknownFields().merge(json, inputs)
+    } catch (e: InvalidProtocolBufferException) {
+      throw IllegalArgumentException("invalid plugins payload JSON: ${e.message}", e)
+    }
+    return inputs.pluginsList
+  }
+}

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -140,6 +140,30 @@ message JvmCompilationTask {
   }
 
   message Inputs {
+      enum PluginPhase {
+        PLUGIN_PHASE_UNSPECIFIED = 0;
+        PLUGIN_PHASE_COMPILE = 1;
+        PLUGIN_PHASE_STUBS = 2;
+      }
+
+      message PluginOption {
+        // Compiler plugin option key
+        string key = 1;
+        // Compiler plugin option value
+        string value = 2;
+      }
+
+      message Plugin {
+        // Kotlin compiler plugin id
+        string id = 1;
+        // Kotlin compiler plugin classpath
+        repeated string classpath = 2;
+        // Kotlin compiler plugin options
+        repeated PluginOption options = 3;
+        // Compilation phases where this plugin should be applied
+        repeated PluginPhase phases = 4;
+      }
+
       // The full classpath
       repeated string classpath = 1;
       // Direct dependencies of the target.
@@ -172,6 +196,8 @@ message JvmCompilationTask {
       repeated string javac_flags = 15;
       // JDeps dependency artifacts
       repeated string deps_artifacts = 16;
+      // Kotlin compiler plugins with explicit phase information.
+      repeated Plugin plugins = 17;
   }
 
   CompilationTaskInfo info = 1;

--- a/src/main/starlark/core/plugin/payload.bzl
+++ b/src/main/starlark/core/plugin/payload.bzl
@@ -1,0 +1,34 @@
+def _phase_to_proto_enum_name(phase):
+    if phase == "compile":
+        return "PLUGIN_PHASE_COMPILE"
+    if phase == "stubs":
+        return "PLUGIN_PHASE_STUBS"
+    fail("Unknown compiler plugin phase: %s" % phase)
+
+def _option_to_json(option):
+    # The legacy option encoding packs "key=value" (or a bare key) into the value
+    # field; split it into the payload's explicit key/value form. A follow-up
+    # commit remodels KtCompilerPluginOption itself as key/value and drops the
+    # split.
+    key, _, value = option.value.partition("=")
+    return {
+        "key": key,
+        "value": value,
+    }
+
+def _plugin_to_json(plugin):
+    return {
+        "classpath": [entry.path for entry in plugin.classpath.to_list()],
+        "id": plugin.id,
+        "options": [_option_to_json(option) for option in plugin.options],
+        "phases": [_phase_to_proto_enum_name(phase) for phase in plugin.phases],
+    }
+
+def _plugins_payload_json(plugins):
+    return json.encode({
+        "plugins": [_plugin_to_json(plugin) for plugin in plugins],
+    })
+
+plugin_payload = struct(
+    plugins_payload_json = _plugins_payload_json,
+)

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -137,6 +137,27 @@ kt_rules_test(
     ],
 )
 
+kt_rules_test(
+    name = "PluginsPayloadParserTest",
+    srcs = ["PluginsPayloadParserTest.kt"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
+        "@kotlin_rules_maven_test//:com_google_truth_truth",
+        "@kotlin_rules_maven_test//:junit_junit",
+    ],
+)
+
+kt_rules_test(
+    name = "PluginsPayloadExpansionTest",
+    srcs = ["PluginsPayloadExpansionTest.kt"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
+        "//src/main/kotlin/io/bazel/worker",
+        "@kotlin_rules_maven_test//:com_google_truth_truth",
+        "@kotlin_rules_maven_test//:junit_junit",
+    ],
+)
+
 test_suite(
     name = "tasks_tests",
     tests = [
@@ -152,5 +173,7 @@ test_suite(
         ":KotlinBuilderJvmStrictDepsTest",
         ":KotlinJvmTaskExecutorTest",
         ":Ksp2TaskTest",
+        ":PluginsPayloadExpansionTest",
+        ":PluginsPayloadParserTest",
     ],
 )

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadExpansionTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadExpansionTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks
+
+import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
+import io.bazel.kotlin.model.JvmCompilationTask
+import io.bazel.worker.Status
+import io.bazel.worker.WorkerContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.nio.file.Files
+
+/**
+ * Pins the worker-side expansion of the plugins payload into the per-phase task fields: the
+ * exact "id:key=value" strings (with the bare "id:key" form for value-less options), their
+ * order, and the per-phase routing that the retired per-phase worker flags used to carry.
+ */
+@RunWith(JUnit4::class)
+class PluginsPayloadExpansionTest {
+  @Test
+  fun expandsPayloadPluginsIntoPerPhaseTaskFields() {
+    val root = Files.createTempDirectory("PluginsPayloadExpansionTest")
+    var captured: JvmCompilationTask? = null
+    val capturingExecutor =
+      object : JvmTaskExecutor {
+        override fun execute(
+          context: CompilationTaskContext,
+          task: JvmCompilationTask,
+        ) {
+          captured = task
+        }
+      }
+
+    WorkerContext.run(named = "test") {
+      doTask("expand", sandboxDir = root) { taskContext ->
+        KotlinBuilder(capturingExecutor).build(
+          taskContext,
+          args =
+            listOf(
+              "--target_label",
+              "//some:target",
+              "--classpath",
+              "dummy.jar",
+              "--direct_dependencies",
+              "--output",
+              root.resolve("out.jar").toString(),
+              "--rule_kind",
+              "kt_jvm_library",
+              "--kotlin_module_name",
+              "some_module",
+              "--kotlin_api_version",
+              "2.0",
+              "--kotlin_language_version",
+              "2.0",
+              "--kotlin_jvm_target",
+              "11",
+              "--kotlin_debug_tags",
+              "--build_kotlin",
+              "false",
+              "--strict_kotlin_deps",
+              "off",
+              "--reduced_classpath_mode",
+              "off",
+              "--instrument_coverage",
+              "false",
+              "--plugins_payload",
+              PAYLOAD,
+            ),
+        )
+        Status.SUCCESS
+      }
+    }
+
+    val inputs = checkNotNull(captured) { "the task never reached the executor" }.inputs
+    assertThat(inputs.stubsPluginClasspathList)
+      .containsExactly("s.jar", "b1.jar", "b2.jar")
+      .inOrder()
+    assertThat(inputs.stubsPluginOptionsList)
+      .containsExactly("p.stubs:a=1", "p.both:flagOnly", "p.both:k=a=b")
+      .inOrder()
+    assertThat(inputs.compilerPluginClasspathList)
+      .containsExactly("c.jar", "b1.jar", "b2.jar")
+      .inOrder()
+    assertThat(inputs.compilerPluginOptionsList)
+      .containsExactly("p.compile:b=2", "p.compile:b=3", "p.both:flagOnly", "p.both:k=a=b")
+      .inOrder()
+  }
+
+  private companion object {
+    val PAYLOAD =
+      """
+      {
+        "plugins": [
+          {
+            "id": "p.stubs",
+            "classpath": ["s.jar"],
+            "options": [{"key": "a", "value": "1"}],
+            "phases": ["PLUGIN_PHASE_STUBS"]
+          },
+          {
+            "id": "p.compile",
+            "classpath": ["c.jar"],
+            "options": [{"key": "b", "value": "2"}, {"key": "b", "value": "3"}],
+            "phases": ["PLUGIN_PHASE_COMPILE"]
+          },
+          {
+            "id": "p.both",
+            "classpath": ["b1.jar", "b2.jar"],
+            "options": [{"key": "flagOnly", "value": ""}, {"key": "k", "value": "a=b"}],
+            "phases": ["PLUGIN_PHASE_STUBS", "PLUGIN_PHASE_COMPILE"]
+          }
+        ]
+      }
+      """.trimIndent()
+  }
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadParserTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/PluginsPayloadParserTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks
+
+import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.model.JvmCompilationTask
+import org.junit.Assert.fail
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class PluginsPayloadParserTest {
+  @Test
+  fun `parses plugins payload json`() {
+    val plugins =
+      PluginsPayloadParser.parse(
+        """
+        {
+          "plugins": [
+            {
+              "id": "plugin.test",
+              "classpath": ["a.jar", "b.jar"],
+              "options": [
+                {"key": "k1", "value": "v1"},
+                {"key": "k2", "value": "v2"}
+              ],
+              "phases": ["PLUGIN_PHASE_COMPILE", "PLUGIN_PHASE_STUBS"]
+            }
+          ]
+        }
+        """.trimIndent(),
+      )
+
+    assertThat(plugins).hasSize(1)
+    val plugin = plugins.single()
+    assertThat(plugin.id).isEqualTo("plugin.test")
+    assertThat(plugin.classpathList).containsExactly("a.jar", "b.jar").inOrder()
+    assertThat(plugin.optionsList.map { "${it.key}=${it.value}" })
+      .containsExactly("k1=v1", "k2=v2")
+      .inOrder()
+    assertThat(plugin.phasesList)
+      .containsExactly(
+        JvmCompilationTask.Inputs.PluginPhase.PLUGIN_PHASE_COMPILE,
+        JvmCompilationTask.Inputs.PluginPhase.PLUGIN_PHASE_STUBS,
+      )
+      .inOrder()
+  }
+
+  @Test
+  fun `ignores unknown json fields`() {
+    val plugins =
+      PluginsPayloadParser.parse(
+        """
+        {
+          "unknown_top_level": "ignored",
+          "plugins": [
+            {
+              "id": "plugin.unknown",
+              "classpath": [],
+              "options": [],
+              "phases": ["PLUGIN_PHASE_COMPILE"],
+              "unknown_nested": "ignored"
+            }
+          ]
+        }
+        """.trimIndent(),
+      )
+
+    assertThat(plugins).hasSize(1)
+    assertThat(plugins.single().id).isEqualTo("plugin.unknown")
+  }
+
+  @Test
+  fun `silently drops unknown phase enum names`() {
+    // JsonFormat's ignoringUnknownFields() also ignores unknown enum VALUES: an unrecognized
+    // phase name is dropped rather than rejected. Pinned so a protobuf behavior change (or a
+    // stricter parser) surfaces here instead of as a silent contract shift.
+    val plugins =
+      PluginsPayloadParser.parse(
+        """
+        {"plugins": [{"id": "p", "classpath": [], "options": [], "phases": ["PLUGIN_PHASE_BOGUS"]}]}
+        """.trimIndent(),
+      )
+
+    assertThat(plugins.single().phasesList).isEmpty()
+  }
+
+  @Test
+  fun `parses an empty payload object to no plugins`() {
+    assertThat(PluginsPayloadParser.parse("{}")).isEmpty()
+  }
+
+  @Test
+  fun `rejects invalid json`() {
+    try {
+      PluginsPayloadParser.parse("{invalid")
+      fail("Expected parse to fail")
+    } catch (e: IllegalArgumentException) {
+      assertThat(e).hasMessageThat().contains("invalid plugins payload JSON")
+    }
+  }
+}

--- a/src/test/starlark/core/plugin/kapt/kapt_test.bzl
+++ b/src/test/starlark/core/plugin/kapt/kapt_test.bzl
@@ -3,7 +3,15 @@ load("//kotlin:core.bzl", "kt_plugin_cfg")
 load("//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_import", "kt_jvm_library")
 load("//kotlin/compiler:kapt.bzl", "kapt_compiler_plugin")
 load("//src/test/starlark:case.bzl", "Want", "suite")
-load("//src/test/starlark:truth.bzl", "flags_and_values_of")
+load("//src/test/starlark:truth.bzl", "flags_and_values_of", "payload_plugins_of")
+
+# The per-phase plugin flags the plugins payload replaced; no action may carry them.
+_RETIRED_PLUGIN_FLAGS = [
+    "--compiler_plugin_classpath",
+    "--compiler_plugin_options",
+    "--stubs_plugin_classpath",
+    "--stubs_plugin_options",
+]
 
 def _normalize_path_with_cfg(file):
     """Attempts to normalize the file to standard configs.
@@ -56,7 +64,19 @@ def _action(env, got):
         for r in env.ctx.attr.runfiles
         for f in r[DefaultInfo].files.to_list()
     ])
-    flags_and_values_of(compile).contains_at_least(env.ctx.attr.flags.items())
+    parsed_flags = flags_and_values_of(compile)
+    parsed_flags.contains_at_least(env.ctx.attr.flags.items())
+    got_flag_keys = parsed_flags.transform(
+        desc = "flag keys",
+        map_each = lambda item: item[0],
+    )
+    flag_keys = getattr(env.ctx.attr, "flag_keys", [])
+    if flag_keys:
+        got_flag_keys.contains_at_least(flag_keys)
+    got_flag_keys.contains_none_of(_RETIRED_PLUGIN_FLAGS)
+    payload_plugins = getattr(env.ctx.attr, "payload_plugins", [])
+    if payload_plugins:
+        payload_plugins_of(compile).contains_exactly(payload_plugins)
 
 def _apoptions_to_kotlinc(rule_under_test, **kwargs):
     def test(test):
@@ -110,17 +130,29 @@ def _apoptions_to_kotlinc(rule_under_test, **kwargs):
                     attr = attr.label_list(allow_empty = True, allow_files = True, cfg = "exec"),
                     value = [dep_jar],
                 ),
+                "flag_keys": Want(
+                    attr = attr.string_list(),
+                    value = ["--plugins_payload"],
+                ),
                 "flags": Want(
                     attr = attr.string_list_dict(),
                     value = {
-                        "--stubs_plugin_options": [
-                            "org.jetbrains.kotlin.kapt3:apoption=%s:%s" % (option_key, option_value),
-                        ],
                     },
                 ),
                 "mnemonic": Want(
                     attr = attr.string(),
                     value = "KotlinKapt",
+                ),
+                "payload_plugins": Want(
+                    attr = attr.string_list(),
+                    value = [
+                        "id=org.jetbrains.kotlin.kapt3 " +
+                        "classpath=[processed_dagger-2.57.2.jar," +
+                        "processed_jakarta.inject-api-2.0.1.jar," +
+                        "processed_javax.inject-1.jar,processed_jspecify-1.0.0.jar," +
+                        "{}_dep.jar] ".format(test.name) +
+                        "phases=[PLUGIN_PHASE_STUBS] options=[apoption=hold:keep]",
+                    ],
                 ),
                 "runfiles": Want(
                     attr = attr.label_list(allow_empty = True, allow_files = True),

--- a/src/test/starlark/core/plugin/test.bzl
+++ b/src/test/starlark/core/plugin/test.bzl
@@ -4,7 +4,7 @@ load("//kotlin:core.bzl", "kt_compiler_plugin", "kt_plugin_cfg")
 load("//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
 load("//src/main/starlark/core/plugin:providers.bzl", "KtCompilerPluginInfo", "KtPluginConfiguration")
 load("//src/test/starlark:case.bzl", "suite")
-load("//src/test/starlark:truth.bzl", "fail_messages_in", "flags_and_values_of")
+load("//src/test/starlark:truth.bzl", "fail_messages_in", "flags_and_values_of", "payload_plugins_of")
 load(":subjects.bzl", "plugin_configuration_subject_factory")
 
 def _provider_test_impl(env, target):
@@ -15,13 +15,59 @@ def _provider_test_impl(env, target):
     got_provider.options().transform(desc = "option.value", map_each = lambda o: o.value).contains_at_least(want_options)
     got_provider.id().equals(env.ctx.attr.want_plugin[KtCompilerPluginInfo].id)
 
+# The per-phase plugin flags the plugins payload replaced; no action may carry them.
+_RETIRED_PLUGIN_FLAGS = [
+    "--compiler_plugin_classpath",
+    "--compiler_plugin_options",
+    "--stubs_plugin_classpath",
+    "--stubs_plugin_options",
+]
+
 def _action_test_impl(env, target):
     action = env.expect.that_target(target).action_named(env.ctx.attr.on_action_mnemonic)
     action.inputs().contains_at_least([f.short_path for f in env.ctx.files.want_inputs])
-    flags_and_values_of(action).contains_at_least(env.ctx.attr.want_flags.items())
+    parsed_flags = flags_and_values_of(action)
+    parsed_flags.contains_at_least(env.ctx.attr.want_flags.items())
+    flag_keys = parsed_flags.transform(
+        desc = "flag keys",
+        map_each = lambda item: item[0],
+    )
+    if env.ctx.attr.want_flag_keys:
+        flag_keys.contains_at_least(env.ctx.attr.want_flag_keys)
+    flag_keys.contains_none_of(_RETIRED_PLUGIN_FLAGS)
+    if env.ctx.attr.want_payload_plugins:
+        payload_plugins_of(action).contains_exactly(env.ctx.attr.want_payload_plugins)
+
+def _inline_payload_test_impl(env, target):
+    action = env.expect.that_target(target).action_named("KotlinCompile")
+    action.argv().transform(
+        desc = "inline --plugins_payload plugin ids",
+        loop = _inline_payload_plugin_ids,
+    ).contains(env.ctx.attr.want_plugin_id)
+
+def _inline_payload_plugin_ids(argv):
+    if argv == None:
+        return []
+    for i, arg in enumerate(argv):
+        if arg != "--plugins_payload" or i + 1 >= len(argv):
+            continue
+        value = argv[i + 1]
+        if not value.startswith("{"):
+            # A params-file reference or split value breaks the inline JSON contract.
+            return []
+        return [plugin["id"] for plugin in json.decode(value)["plugins"]]
+    return []
 
 def _expect_failure(env, target):
     fail_messages_in(env.expect.that_target(target)).contains_at_least(env.ctx.attr.want_failures)
+
+def _expect_failure_contains(env, target):
+    failures = fail_messages_in(env.expect.that_target(target))
+    for want in env.ctx.attr.want_failure_substrings:
+        failures.transform(
+            desc = "contains '%s'" % want,
+            map_each = lambda f: want in f,
+        ).contains(True)
 
 def plugin_for(test, name, deps = [], id = None, **kwargs):
     plugin_jar = test.artifact(
@@ -107,6 +153,56 @@ def _test_kt_plugin_cfg(test):
         },
     )
 
+def _test_kt_plugin_cfg_multi_value_options(test):
+    plugin = test.have(
+        kt_compiler_plugin,
+        name = "plugin",
+        id = "test.multi",
+        deps = [
+            test.have(
+                kt_jvm_library,
+                name = "plugin_dep",
+                srcs = [
+                    test.artifact(
+                        name = "plugin.kt",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    cfg = test.got(
+        kt_plugin_cfg,
+        name = "got",
+        plugin = plugin,
+        options = {
+            "annotation": [
+                "plugin.First",
+                "plugin.Second",
+            ],
+        },
+        deps = [],
+    )
+
+    analysis_test(
+        name = test.name,
+        impl = _provider_test_impl,
+        target = cfg,
+        attr_values = {
+            "want_deps": [],
+            "want_options": [
+                "annotation=plugin.First",
+                "annotation=plugin.Second",
+            ],
+            "want_plugin": plugin,
+        },
+        attrs = {
+            "want_deps": attr.label_list(providers = [JavaInfo]),
+            "want_options": attr.string_list(),
+            "want_plugin": attr.label(providers = [KtCompilerPluginInfo]),
+        },
+    )
+
 def _test_compile_configuration(test):
     plugin_jar = test.artifact(
         name = "plugin.jar",
@@ -172,19 +268,69 @@ def _test_compile_configuration(test):
         target = got,
         attr_values = {
             "on_action_mnemonic": "KotlinCompile",
+            "want_flag_keys": ["--plugins_payload"],
             "want_flags": {
-                "--compiler_plugin_options": ["test.stub:annotation=plugin.StubForTesting", "test.stub:-Dop=koo"],
-                "--stubs_plugin_options": ["test.stub:annotation=plugin.StubForTesting", "test.stub:-Dop=koo"],
             },
             "want_inputs": [
                 plugin_jar,
                 dep_jar,
             ],
+            "want_payload_plugins": [
+                "id=test.stub classpath=[{n}_plugin.jar,{n}_dep.jar] ".format(n = test.name) +
+                "phases=[PLUGIN_PHASE_COMPILE,PLUGIN_PHASE_STUBS] " +
+                "options=[annotation=plugin.StubForTesting,-Dop=koo]",
+            ],
         },
         attrs = {
             "on_action_mnemonic": attr.string(),
+            "want_flag_keys": attr.string_list(),
             "want_flags": attr.string_list_dict(),
             "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_payload_plugins": attr.string_list(),
+        },
+    )
+
+def _test_compile_configuration_inline_payload_json(test):
+    plugin = test.have(
+        kt_compiler_plugin,
+        name = "plugin",
+        id = "test.inline.payload",
+        options = {
+            "annotation": "plugin.StubForTesting",
+        },
+        deps = [
+            test.have(
+                kt_jvm_import,
+                name = "plugin_jar",
+                jars = [
+                    test.artifact(
+                        name = "plugin.jar",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    got = test.got(
+        kt_jvm_library,
+        name = "got_library",
+        srcs = [
+            test.artifact(
+                name = "got_library.kt",
+            ),
+        ],
+        plugins = [plugin],
+    )
+
+    analysis_test(
+        name = test.name,
+        impl = _inline_payload_test_impl,
+        target = got,
+        attr_values = {
+            "want_plugin_id": "test.inline.payload",
+        },
+        attrs = {
+            "want_plugin_id": attr.string(),
         },
     )
 
@@ -275,28 +421,26 @@ def _test_compile_multiple_configurations(test):
         target = got,
         attr_values = {
             "on_action_mnemonic": "KotlinCompile",
+            "want_flag_keys": ["--plugins_payload"],
             "want_flags": {
-                "--compiler_plugin_options": [
-                    "test.stub:annotation=plugin.StubForTesting",
-                    "test.stub:-Dop=koo",
-                    "test.stub:-Dop=zubzub",
-                ],
-                "--stubs_plugin_options": [
-                    "test.stub:annotation=plugin.StubForTesting",
-                    "test.stub:-Dop=koo",
-                    "test.stub:-Dop=zubzub",
-                ],
             },
             "want_inputs": [
                 plugin_jar,
                 dep_a_jar,
                 dep_b_jar,
             ],
+            "want_payload_plugins": [
+                "id=test.stub classpath=[{n}_plugin.jar,{n}_a_dep.jar,{n}_b_dep.jar] ".format(n = test.name) +
+                "phases=[PLUGIN_PHASE_COMPILE,PLUGIN_PHASE_STUBS] " +
+                "options=[annotation=plugin.StubForTesting,-Dop=koo,-Dop=zubzub]",
+            ],
         },
         attrs = {
             "on_action_mnemonic": attr.string(),
+            "want_flag_keys": attr.string_list(),
             "want_flags": attr.string_list_dict(),
             "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_payload_plugins": attr.string_list(),
         },
     )
 
@@ -357,19 +501,26 @@ def _test_compile_configuration_single_phase(test):
         target = got,
         attr_values = {
             "on_action_mnemonic": "KotlinCompile",
+            "want_flag_keys": ["--plugins_payload"],
             "want_flags": {
-                "--compiler_plugin_options": ["plugin.compile:-Dop=compile_only"],
-                "--stubs_plugin_options": ["plugin.stub:-Dop=stub_only"],
             },
             "want_inputs": [
                 stub_jar,
                 compile_jar,
             ],
+            "want_payload_plugins": [
+                "id=plugin.stub classpath=[{n}_stub.jar] ".format(n = test.name) +
+                "phases=[PLUGIN_PHASE_STUBS] options=[-Dop=stub_only]",
+                "id=plugin.compile classpath=[{n}_compile.jar] ".format(n = test.name) +
+                "phases=[PLUGIN_PHASE_COMPILE] options=[-Dop=compile_only]",
+            ],
         },
         attrs = {
             "on_action_mnemonic": attr.string(),
+            "want_flag_keys": attr.string_list(),
             "want_flags": attr.string_list_dict(),
             "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_payload_plugins": attr.string_list(),
         },
     )
 
@@ -439,12 +590,51 @@ def _test_library_multiple_plugins_with_same_id(test):
         },
     )
 
+def _test_library_plugin_without_phase(test):
+    (plugin, _) = plugin_for(
+        test,
+        name = "no_phase_plugin",
+        id = "test.no_phase",
+        compile_phase = False,
+        stubs_phase = False,
+    )
+
+    got = test.got(
+        kt_jvm_library,
+        name = "got_library",
+        srcs = [
+            test.artifact(
+                name = "got_library.kt",
+            ),
+        ],
+        plugins = [plugin],
+    )
+
+    analysis_test(
+        name = test.name,
+        impl = _expect_failure_contains,
+        expect_failure = True,
+        target = got,
+        attr_values = {
+            "want_failure_substrings": [
+                "has plugin without a phase defined:",
+                "test.no_phase",
+            ],
+        },
+        attrs = {
+            "want_failure_substrings": attr.string_list(),
+        },
+    )
+
 def test_suite(name):
     suite(
         name,
         test_kt_plugin_cfg = _test_kt_plugin_cfg,
+        test_kt_plugin_cfg_multi_value_options = _test_kt_plugin_cfg_multi_value_options,
         test_compile_configuration = _test_compile_configuration,
+        test_compile_configuration_inline_payload_json = _test_compile_configuration_inline_payload_json,
         test_library_multiple_plugins_with_same_id = _test_library_multiple_plugins_with_same_id,
+        test_library_plugin_without_phase = _test_library_plugin_without_phase,
         test_compile_configuration_single_phase = _test_compile_configuration_single_phase,
         test_compile_multiple_configurations = _test_compile_multiple_configurations,
     )

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -6,6 +6,7 @@ load(":javac_warn_test.bzl", "javac_warn_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kotlinc_options_test.bzl", "kotlinc_options_test_suite")
 load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
+load(":plugin_payload_test.bzl", "plugin_payload_test_suite")
 load(":sourceless_library_test.bzl", "sourceless_library_test_suite")
 
 export_only_module_name_test_suite(name = "export_only_module_name_tests")
@@ -23,5 +24,7 @@ jvm_deps_test_suite(name = "jvm_tests")
 kotlinc_options_test_suite(name = "kotlinc_options_tests")
 
 kt_jvm_binary_env_test_suite(name = "kt_jvm_binary_env_tests")
+
+plugin_payload_test_suite(name = "plugin_payload_tests")
 
 sourceless_library_test_suite(name = "sourceless_library_tests")

--- a/src/test/starlark/internal/jvm/plugin_payload_test.bzl
+++ b/src/test/starlark/internal/jvm/plugin_payload_test.bzl
@@ -1,0 +1,96 @@
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "asserts",
+    "unittest",
+)
+load("//src/main/starlark/core/plugin:payload.bzl", "plugin_payload")
+
+def _plugins_payload_json_encodes_empty_plugins_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env,
+        {"plugins": []},
+        json.decode(plugin_payload.plugins_payload_json([])),
+    )
+
+    return unittest.end(env)
+
+plugins_payload_json_encodes_empty_plugins_test = unittest.make(
+    _plugins_payload_json_encodes_empty_plugins_test_impl,
+)
+
+def _plugins_payload_json_encodes_populated_plugin_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Mirror the example parsed by PluginsPayloadParserTest.kt so the producer's emitted JSON
+    # shape and the Kotlin proto/JsonFormat parser stay locked to the same contract: a drift in
+    # either the JSON keys here or the proto field/enum names there breaks one of the two tests.
+    plugin = struct(
+        id = "plugin.test",
+        classpath = depset([struct(path = "a.jar"), struct(path = "b.jar")]),
+        options = [
+            struct(id = "plugin.test", value = "k1=v1"),
+            struct(id = "plugin.test", value = "k2=v2"),
+        ],
+        phases = ["compile", "stubs"],
+    )
+
+    decoded = json.decode(plugin_payload.plugins_payload_json([plugin]))
+
+    asserts.equals(env, 1, len(decoded["plugins"]))
+    plugin_json = decoded["plugins"][0]
+    asserts.equals(env, "plugin.test", plugin_json["id"])
+    asserts.equals(env, ["a.jar", "b.jar"], plugin_json["classpath"])
+    asserts.equals(
+        env,
+        [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}],
+        plugin_json["options"],
+    )
+
+    # `phases` carries the proto enum *names* the JsonFormat parser maps to PluginPhase values.
+    asserts.equals(env, ["PLUGIN_PHASE_COMPILE", "PLUGIN_PHASE_STUBS"], plugin_json["phases"])
+
+    return unittest.end(env)
+
+plugins_payload_json_encodes_populated_plugin_test = unittest.make(
+    _plugins_payload_json_encodes_populated_plugin_test_impl,
+)
+
+def _plugins_payload_json_encodes_edge_options_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # A value-less option must encode with an empty value (the worker re-emits it as a bare
+    # "id:key" argument), and a value containing '=' must split at the FIRST '=' so the rest
+    # survives whole.
+    plugin = struct(
+        id = "plugin.edge",
+        classpath = depset([struct(path = "p.jar")]),
+        options = [
+            struct(id = "plugin.edge", value = "flagOnly"),
+            struct(id = "plugin.edge", value = "k=a=b"),
+        ],
+        phases = ["compile"],
+    )
+
+    decoded = json.decode(plugin_payload.plugins_payload_json([plugin]))
+
+    asserts.equals(
+        env,
+        [{"key": "flagOnly", "value": ""}, {"key": "k", "value": "a=b"}],
+        decoded["plugins"][0]["options"],
+    )
+
+    return unittest.end(env)
+
+plugins_payload_json_encodes_edge_options_test = unittest.make(
+    _plugins_payload_json_encodes_edge_options_test_impl,
+)
+
+def plugin_payload_test_suite(name):
+    unittest.suite(
+        name,
+        plugins_payload_json_encodes_empty_plugins_test,
+        plugins_payload_json_encodes_populated_plugin_test,
+        plugins_payload_json_encodes_edge_options_test,
+    )

--- a/src/test/starlark/truth.bzl
+++ b/src/test/starlark/truth.bzl
@@ -11,6 +11,33 @@ def fail_messages_in(target_subject):
 def flags_and_values_of(action_subject):
     return action_subject.argv().transform(desc = "parsed()", loop = _action_subject_parse_flags)
 
+def payload_plugins_of(action_subject):
+    """The --plugins_payload plugins, one normalized string per plugin."""
+    return action_subject.argv().transform(
+        desc = "plugins payload plugins",
+        loop = _action_subject_parse_payload_plugins,
+    )
+
+def _action_subject_parse_payload_plugins(argv):
+    if argv == None:
+        return []
+    payload = None
+    for i, arg in enumerate(argv):
+        if arg == "--plugins_payload" and i + 1 < len(argv):
+            payload = argv[i + 1]
+            break
+    if payload == None:
+        return []
+    return [
+        "id={id} classpath=[{classpath}] phases=[{phases}] options=[{options}]".format(
+            id = plugin["id"],
+            classpath = ",".join([entry.rsplit("/", 1)[-1] for entry in plugin["classpath"]]),
+            phases = ",".join(plugin["phases"]),
+            options = ",".join(["%s=%s" % (o["key"], o["value"]) for o in plugin["options"]]),
+        )
+        for plugin in json.decode(payload)["plugins"]
+    ]
+
 def _action_subject_parse_flags(argv):
     parsed_flags = {}
 


### PR DESCRIPTION
Replace the four per-phase string-list worker flags (stubs/compiler plugin classpath + options) with one self-describing --plugins_payload JSON argument: the typed plugin transport the Build Tools API compilation uses.

- introduce new Plugin proto messages (id, classpath, key/value options, phases) the payload is parsed into; the worker expands them into the existing per-phase task fields, so the -Xplugin/-P arguments handed to kotlinc are unchanged for both the legacy and the Build Tools API invocation
- plugin options still arrive in their legacy packed "key=value" form and are split at the first '='; cleaner key/value handling of KtCompilerPluginOption is done later in a separate commit
- the payload contract is tested on both ends against the same example (Starlark producer, Kotlin parser)