### PR TITLE
Pass compiler plugins as structured descriptors to the Build Tools AP…

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiInvoker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiInvoker.kt
@@ -19,6 +19,7 @@ package io.bazel.kotlin.builder.tasks.jvm.btapi
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 import io.bazel.kotlin.compiler.CompilationUnit
 import io.bazel.kotlin.compiler.CompilerConfiguration
+import io.bazel.kotlin.compiler.CompilerPluginSpec
 import io.bazel.kotlin.compiler.KotlinBtapiCompiler
 import java.io.PrintStream
 import java.lang.invoke.MethodHandle
@@ -38,6 +39,7 @@ class BtapiInvoker(
   private val execHandle: MethodHandle
   private val compilationUnitDispatcher = Dispatcher(CompilationUnit::class.java)
   private val configurationDispatcher = Dispatcher(CompilerConfiguration::class.java)
+  private val pluginDispatcher = Dispatcher(CompilerPluginSpec::class.java)
 
   init {
     val compilerClass = btapiClassLoader.loadClass("io.bazel.kotlin.compiler.BuildToolsAPICompiler")
@@ -64,12 +66,14 @@ class BtapiInvoker(
     errStream: PrintStream,
     compilationUnit: CompilationUnit,
     configuration: CompilerConfiguration,
+    plugins: List<CompilerPluginSpec>,
   ): Int =
     execHandle.invoke(
       compilerImpl,
       errStream,
       compilationUnitDispatcher.applyTo(compilationUnit),
       configurationDispatcher.applyTo(configuration),
+      plugins.map(pluginDispatcher::applyTo),
     ) as Int
 
   /**

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
@@ -18,7 +18,6 @@ package io.bazel.kotlin.builder.tasks.jvm.btapi
 
 import com.google.devtools.build.lib.view.proto.Deps
 import io.bazel.kotlin.builder.tasks.JvmTaskExecutor
-import io.bazel.kotlin.builder.tasks.jvm.CompilationArgs
 import io.bazel.kotlin.builder.tasks.jvm.InternalCompilerPlugins
 import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.emptyJdeps
 import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.writeJdeps
@@ -30,16 +29,20 @@ import io.bazel.kotlin.builder.tasks.jvm.createGeneratedKspKotlinSrcJar
 import io.bazel.kotlin.builder.tasks.jvm.createGeneratedStubJar
 import io.bazel.kotlin.builder.tasks.jvm.createOutputJar
 import io.bazel.kotlin.builder.tasks.jvm.createdGeneratedKspClassesJar
+import io.bazel.kotlin.builder.tasks.jvm.encodeMap
 import io.bazel.kotlin.builder.tasks.jvm.expandWithGeneratedSources
-import io.bazel.kotlin.builder.tasks.jvm.kaptArgs
-import io.bazel.kotlin.builder.tasks.jvm.plugins
+import io.bazel.kotlin.builder.tasks.jvm.incrementalData
 import io.bazel.kotlin.builder.tasks.jvm.preProcessingSteps
+import io.bazel.kotlin.builder.tasks.jvm.stubs
 import io.bazel.kotlin.builder.toolchain.CompilationStatusException
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.compiler.CompilationUnit
 import io.bazel.kotlin.compiler.CompilerConfiguration
+import io.bazel.kotlin.compiler.CompilerPluginSpec
 import io.bazel.kotlin.model.JvmCompilationTask
+import io.bazel.kotlin.model.JvmCompilationTask.Inputs.PluginPhase
 import java.io.BufferedInputStream
+import java.io.File
 import java.io.PrintStream
 import java.nio.file.Paths
 
@@ -50,6 +53,13 @@ class BtapiTaskExecutor(
   private val invoker: BtapiInvoker,
   private val plugins: InternalCompilerPlugins,
 ) : JvmTaskExecutor {
+  private data class PluginDescriptor(
+    override val id: String,
+    override val classpath: List<String>,
+    /** Each option is a `key=value` string; option keys cannot contain `=`. */
+    override val options: List<String>,
+  ) : CompilerPluginSpec
+
   override fun execute(
     context: CompilationTaskContext,
     task: JvmCompilationTask,
@@ -126,15 +136,24 @@ class BtapiTaskExecutor(
       return this
     }
     return context.execute("kapt (${inputs.processorsList.joinToString(", ")})") {
-      val arguments =
-        plugins(
-          options = inputs.stubsPluginOptionsList.filterNot { o -> o.startsWith(plugins.kapt.id) },
-          classpath = inputs.stubsPluginClasspathList,
-        ).append(kaptArgs(context, plugins, "stubsAndApt"))
-          .list()
+      val descriptors =
+        listOf(kaptPluginDescriptor(context)) +
+          userPluginDescriptors(PluginPhase.PLUGIN_PHASE_STUBS)
       context
         .executeCompilerTask(
-          { out -> invokeCompiler(context, arguments, directories.generatedClasses, out) },
+          { out ->
+            // Like the legacy pre-pass, this compiles with the toolchain's base arguments only:
+            // the user's pass-through flags and the friend paths belong to the main compile.
+            invokeCompiler(
+              context,
+              arguments = emptyList(),
+              friendPaths = emptyList(),
+              sources = inputs.kotlinSourcesList + inputs.javaSourcesList,
+              descriptors = descriptors,
+              destination = directories.generatedClasses,
+              out = out,
+            )
+          },
           printOnSuccess = context.whenTracing { true } == true,
         ).let { outputLines ->
           context.whenTracing {
@@ -146,57 +165,78 @@ class BtapiTaskExecutor(
   }
 
   private fun JvmCompilationTask.runKotlinCompiler(context: CompilationTaskContext): List<String> {
-    val arguments =
-      CompilationArgs()
-        .given(outputs.jdeps)
-        .notEmpty {
-          plugin(plugins.jdeps) {
-            flag("output", outputs.jdeps)
-            flag("target_label", info.label)
-            inputs.directDependenciesList.forEach {
-              flag("direct_dependencies", it)
-            }
-            inputs.classpathList.forEach {
-              flag("full_classpath", it)
-            }
-            flag("strict_kotlin_deps", info.strictKotlinDeps)
-          }
-        }.given(outputs.abijar)
-        .notEmpty {
-          plugin(plugins.jvmAbiGen) {
-            flag("outputDir", directories.abiClasses)
-            if (info.treatInternalAsPrivateInAbiJar) {
-              flag("treatInternalAsPrivate", "true")
-            }
-            if (info.removePrivateClassesInAbiJar) {
-              flag("removePrivateClasses", "true")
-            }
-            if (info.removeDebugInfo) {
-              flag("removeDebugInfo", "true")
-            }
-            if (info.preserveDeclarationOrder) {
-              flag("preserveDeclarationOrder", "true")
-            }
-            if (info.removeDataClassCopyIfConstructorIsPrivate) {
-              flag("removeDataClassCopyIfConstructorIsPrivate", "true")
-            }
-          }
-          given(outputs.jar).empty {
-            plugin(plugins.skipCodeGen)
-          }
-        }.values(info.passthroughFlagsList)
-        .append(
-          plugins(
-            options = inputs.compilerPluginOptionsList,
-            classpath = inputs.compilerPluginClasspathList,
+    val descriptors = mutableListOf<PluginDescriptor>()
+
+    if (outputs.jdeps.isNotEmpty()) {
+      descriptors.add(
+        PluginDescriptor(
+          id = plugins.jdeps.id,
+          classpath = listOf(plugins.jdeps.jarPath),
+          options =
+            listOf(
+              "output=${outputs.jdeps}",
+              "target_label=${info.label}",
+            ) +
+              inputs.directDependenciesList.map { "direct_dependencies=$it" } +
+              inputs.classpathList.map { "full_classpath=$it" } +
+              listOf("strict_kotlin_deps=${info.strictKotlinDeps}"),
+        ),
+      )
+    }
+    if (outputs.abijar.isNotEmpty()) {
+      val abiOptions = mutableListOf("outputDir=${directories.abiClasses}")
+      if (info.treatInternalAsPrivateInAbiJar) {
+        abiOptions.add("treatInternalAsPrivate=true")
+      }
+      if (info.removePrivateClassesInAbiJar) {
+        abiOptions.add("removePrivateClasses=true")
+      }
+      if (info.removeDebugInfo) {
+        abiOptions.add("removeDebugInfo=true")
+      }
+      if (info.preserveDeclarationOrder) {
+        abiOptions.add("preserveDeclarationOrder=true")
+      }
+      if (info.removeDataClassCopyIfConstructorIsPrivate) {
+        abiOptions.add("removeDataClassCopyIfConstructorIsPrivate=true")
+      }
+      descriptors.add(
+        PluginDescriptor(
+          id = plugins.jvmAbiGen.id,
+          classpath = listOf(plugins.jvmAbiGen.jarPath),
+          options = abiOptions,
+        ),
+      )
+      if (outputs.jar.isEmpty()) {
+        descriptors.add(
+          PluginDescriptor(
+            id = plugins.skipCodeGen.id,
+            classpath = listOf(plugins.skipCodeGen.jarPath),
+            options = emptyList(),
           ),
-        ).list()
+        )
+      }
+    }
+    descriptors.addAll(userPluginDescriptors(PluginPhase.PLUGIN_PHASE_COMPILE))
 
     context.whenTracing {
-      context.printLines("Kotlin Compiler arguments:\n", arguments)
+      context.printLines(
+        "Kotlin Compiler plugins:\n",
+        descriptors.map { "${it.id} ${it.options}" },
+      )
     }
     return context.executeCompilerTask(
-      { out -> invokeCompiler(context, arguments, directories.classes, out) },
+      { out ->
+        invokeCompiler(
+          context,
+          arguments = info.passthroughFlagsList,
+          friendPaths = info.friendPathsList,
+          sources = inputs.javaSourcesList + inputs.kotlinSourcesList,
+          descriptors = descriptors,
+          destination = directories.classes,
+          out = out,
+        )
+      },
       printOnFail = false,
     )
   }
@@ -217,9 +257,90 @@ class BtapiTaskExecutor(
     override val verbose: Boolean,
   ) : CompilerConfiguration
 
+  /**
+   * The user's structured plugins for one phase, excluding kapt (which the pre-pass configures itself).
+   */
+  private fun JvmCompilationTask.userPluginDescriptors(phase: PluginPhase): List<PluginDescriptor> =
+    inputs.pluginsList
+      .filter { phase in it.phasesList && it.id != plugins.kapt.id }
+      .map { plugin ->
+        val tokens =
+          mapOf(
+            "{generatedClasses}" to directories.generatedClasses,
+            "{stubs}" to directories.stubs,
+            "{temp}" to directories.temp,
+            "{generatedSources}" to directories.generatedSources,
+            "{classpath}" to plugin.classpathList.joinToString(File.pathSeparator),
+          )
+        PluginDescriptor(
+          id = plugin.id,
+          classpath = plugin.classpathList,
+          options =
+            plugin.optionsList.map { option ->
+              val value =
+                tokens.entries.fold(option.value) { formatting, (token, tokenValue) ->
+                  formatting.replace(token, tokenValue)
+                }
+              if (value.isEmpty()) option.key else "${option.key}=$value"
+            },
+        )
+      }
+
+  /**
+   * The kapt plugin configured as a typed descriptor: the stubs-and-apt pre-pass directories,
+   * the javac arguments (both spelling variants, see the legacy kaptArgs contract), the
+   * processors and their classpath, and the user's kapt apOptions decoded from the structured
+   * plugin options.
+   */
+  private fun JvmCompilationTask.kaptPluginDescriptor(
+    context: CompilationTaskContext,
+  ): PluginDescriptor {
+    val jvmTarget = info.toolchainInfo.jvm.jvmTarget
+    val javacArgs =
+      mapOf(
+        "-target" to jvmTarget,
+        "--target" to jvmTarget,
+        "-source" to jvmTarget,
+        "--source" to jvmTarget,
+      )
+    val options = mutableListOf<String>()
+    options.add("sources=${directories.generatedJavaSources}")
+    options.add("classes=${directories.generatedClasses}")
+    options.add("stubs=${directories.stubs}")
+    options.add("incrementalData=${directories.incrementalData}")
+    options.add("javacArguments=${encodeMap(javacArgs)}")
+    options.add("correctErrorTypes=false")
+    options.add("verbose=${context.whenTracing { "true" } ?: "false"}")
+    options.add("aptMode=stubsAndApt")
+    inputs.processorpathsList.forEach { options.add("apclasspath=$it") }
+    inputs.processorsList.forEach { options.add("processors=$it") }
+
+    val apOptions =
+      inputs.pluginsList
+        .asSequence()
+        .filter { it.id == plugins.kapt.id }
+        .flatMap { it.optionsList.asSequence() }
+        .filter { it.key == "apoption" }
+        .map { option ->
+          option.value.split(":", limit = 2).let { it[0] to it.getOrElse(1) { "" } }
+        }.toMap()
+    if (apOptions.isNotEmpty()) {
+      options.add("apoptions=${encodeMap(apOptions)}")
+    }
+
+    return PluginDescriptor(
+      id = plugins.kapt.id,
+      classpath = listOf(plugins.kapt.jarPath),
+      options = options,
+    )
+  }
+
   private fun JvmCompilationTask.invokeCompiler(
     context: CompilationTaskContext,
     arguments: List<String>,
+    friendPaths: List<String>,
+    sources: List<String>,
+    descriptors: List<PluginDescriptor>,
     destination: String,
     out: PrintStream,
   ): Int =
@@ -227,9 +348,9 @@ class BtapiTaskExecutor(
       errStream = out,
       compilationUnit =
         TaskCompilationUnit(
-          sources = inputs.javaSourcesList + inputs.kotlinSourcesList,
+          sources = sources,
           classpath = computeClasspath() + directories.generatedClasses,
-          friendPaths = info.friendPathsList,
+          friendPaths = friendPaths,
           destination = destination,
         ),
       configuration =
@@ -241,6 +362,7 @@ class BtapiTaskExecutor(
           passthroughArguments = arguments,
           verbose = context.whenTracing { true } == true,
         ),
+      plugins = descriptors,
     )
 
   /**

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BuildToolsAPICompiler.kt
@@ -21,6 +21,8 @@ import org.jetbrains.kotlin.buildtools.api.KotlinLogger
 import org.jetbrains.kotlin.buildtools.api.KotlinToolchains
 import org.jetbrains.kotlin.buildtools.api.SharedApiClassesClassLoader
 import org.jetbrains.kotlin.buildtools.api.arguments.CommonCompilerArguments
+import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPlugin
+import org.jetbrains.kotlin.buildtools.api.arguments.CompilerPluginOption
 import org.jetbrains.kotlin.buildtools.api.arguments.ExperimentalCompilerArgument
 import org.jetbrains.kotlin.buildtools.api.arguments.JvmCompilerArguments
 import org.jetbrains.kotlin.buildtools.api.arguments.enums.JdkRelease
@@ -88,6 +90,7 @@ class BuildToolsAPICompiler(
     errStream: PrintStream,
     compilationUnit: CompilationUnit,
     configuration: CompilerConfiguration,
+    plugins: List<CompilerPluginSpec>,
   ): Int {
     System.setProperty("zip.handler.uses.crc.instead.of.timestamp", "true")
 
@@ -101,11 +104,29 @@ class BuildToolsAPICompiler(
 
     val args = operationBuilder.compilerArguments
 
-    // 1. User pass-through flags and compiler plugin arguments (resets the builder; must be first).
+    // 1. User pass-through flags (resets the builder; must be first).
     val passthroughArguments = configuration.passthroughArguments
     if (passthroughArguments.isNotEmpty()) {
       args.applyArgumentStrings(passthroughArguments)
     }
+
+    if (plugins.isNotEmpty()) {
+      args[CommonCompilerArguments.COMPILER_PLUGINS] =
+        plugins.map { plugin ->
+          CompilerPlugin(
+            pluginId = plugin.id,
+            classpath = plugin.classpath.map { Paths.get(it) },
+            rawArguments =
+              plugin.options.map { option ->
+                CompilerPluginOption(option.substringBefore('='), option.substringAfter('=', ""))
+              },
+            orderingRequirements = emptySet(),
+          )
+        }
+    }
+
+    // The default scripting plugin must be 'off' on every compilation. Only .kt and .java sources are compiled.
+    args[CommonCompilerArguments.X_DISABLE_DEFAULT_SCRIPTING_PLUGIN] = true
 
     // 2. Toolchain defaults -- only for options the user did not set, so user flags win.
     var effectiveJvmTarget = args[JvmCompilerArguments.JVM_TARGET]

--- a/src/main/kotlin/io/bazel/kotlin/compiler/KotlinBtapiCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/KotlinBtapiCompiler.kt
@@ -37,6 +37,13 @@ interface CompilerConfiguration {
   val verbose: Boolean
 }
 
+/** One configured compiler plugin; each option is a `key=value` string. */
+interface CompilerPluginSpec {
+  val id: String
+  val classpath: List<String>
+  val options: List<String>
+}
+
 /**
  * The typed Build Tools API compilation contract between the worker and the compiler classloader.
  * Provides structured API to invoke compiler as an in-process utility.
@@ -46,5 +53,6 @@ interface KotlinBtapiCompiler {
     errStream: PrintStream,
     compilationUnit: CompilationUnit,
     configuration: CompilerConfiguration,
+    plugins: List<CompilerPluginSpec>,
   ): Int
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -63,6 +63,10 @@ kt_rules_test(
 kt_rules_test(
     name = "KotlinBuilderJvmBtaTest",
     srcs = ["jvm/KotlinBuilderJvmBtaTest.java"],
+    data = [
+        "auto_value",
+        "auto_value_annotations",
+    ],
 )
 
 kt_rules_test(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBtaTest.java
@@ -15,13 +15,19 @@
  */
 package io.bazel.kotlin.builder.tasks.jvm;
 
+import io.bazel.kotlin.builder.Deps.AnnotationProcessor;
+import io.bazel.kotlin.builder.Deps.Dep;
 import io.bazel.kotlin.builder.DirectoryType;
 import io.bazel.kotlin.builder.KotlinJvmTestBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.util.stream.Collectors;
+
 import static com.google.common.truth.Truth.assertThat;
+import static io.bazel.kotlin.builder.KotlinJvmTestBuilder.KOTLIN_ANNOTATIONS;
+import static io.bazel.kotlin.builder.KotlinJvmTestBuilder.KOTLIN_STDLIB;
 
 /** Compiles through the Build Tools API path ({@code --build_tools_api=true}). */
 @RunWith(JUnit4.class)
@@ -141,6 +147,55 @@ public class KotlinBuilderJvmBtaTest {
                     c.outputJdeps();
                 });
         assertThat(ctx.classFileMajorVersion("something/AClass.class")).isEqualTo(61);
+    }
+
+    @Test
+    public void testKaptRunsThroughTypedPluginConfig() {
+        // On the Build Tools API path the KAPT stubs-and-apt pre-pass is configured as a typed
+        // plugin descriptor (no base64 -P configuration blob); the annotation processor must
+        // still run and generate sources that are compiled into the output.
+        Dep autoValueAnnotations = Dep.fromLabel("auto_value_annotations");
+        Dep autoValue = Dep.fromLabel("auto_value");
+        AnnotationProcessor autoValueProcessor =
+                AnnotationProcessor.builder()
+                        .processClass("com.google.auto.value.processor.AutoValueProcessor")
+                        .processorPath(
+                                Dep.classpathOf(autoValueAnnotations, autoValue, KOTLIN_ANNOTATIONS)
+                                        .collect(Collectors.toSet()))
+                        .build();
+
+        ctx.runCompileTask(
+                c -> {
+                    c.useBuildToolsApi();
+                    c.compileKotlin();
+                    c.addAnnotationProcessors(autoValueProcessor);
+                    c.addDirectDependencies(autoValueAnnotations, KOTLIN_ANNOTATIONS, KOTLIN_STDLIB);
+                    c.addSource(
+                            "TestKtValue.kt",
+                            "package autovalue\n"
+                                    + "\n"
+                                    + "import com.google.auto.value.AutoValue\n"
+                                    + "\n"
+                                    + "@AutoValue\n"
+                                    + "abstract class TestKtValue {\n"
+                                    + "    abstract fun name(): String\n"
+                                    + "    fun builder(): Builder = AutoValue_TestKtValue.Builder()\n"
+                                    + "\n"
+                                    + "    @AutoValue.Builder\n"
+                                    + "    abstract class Builder {\n"
+                                    + "        abstract fun setName(name: String): Builder\n"
+                                    + "        abstract fun build(): TestKtValue\n"
+                                    + "    }\n"
+                                    + "}");
+                    c.outputJar();
+                    c.outputJdeps();
+                    c.generatedSourceJar();
+                    c.ktStubsJar();
+                    c.incrementalData();
+                });
+
+        ctx.assertFilesExist(DirectoryType.JAVA_SOURCE_GEN, "autovalue/AutoValue_TestKtValue.java");
+        ctx.assertFilesExist(DirectoryType.CLASSES, "autovalue/TestKtValue.class");
     }
 
     @Test


### PR DESCRIPTION
…I compiler

Model compiler plugins as a typed part of the Build Tools API compilation contract instead of argument strings.

- The KotlinBtapiCompiler invocation contract gains a list of CompilerPluginSpec plugin descriptors; the legacy invocation is untouched.
- The compiler side applies the descriptors through the typed COMPILER_PLUGINS argument key.
- The default scripting plugin is explicitly disabled on every compilation.
- The KAPT pre-pass mirrors the legacy contract exactly.
- The new KotlinBuilderJvmBtaTest case runs an annotation processor (AutoValue) through the typed plugin configuration and asserts the generated source is produced and compiled into the output.