### PR TITLE
Add Java release 25 support to kt_javac_options

### DIFF
--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -49,13 +49,14 @@ _JOPTS = {
         args = dict(
             default = "default",
             doc = "Compile for the specified Java SE release",
-            values = ["default", "8", "11", "17", "21"],
+            values = ["default", "8", "11", "17", "21", "25"],
         ),
         type = attr.string,
         value_to_flag = {
             "11": ["--release 11"],
             "17": ["--release 17"],
             "21": ["--release 21"],
+            "25": ["--release 25"],
             "8": ["--release 8"],
             "default": None,
         },

--- a/src/test/starlark/internal/jvm/javac_options_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_options_test.bzl
@@ -83,11 +83,18 @@ _mixed_target_explicit_no_proc_test = analysistest.make(_mixed_target_explicit_n
 def _release_flag_reaches_javac_test_impl(ctx):
     env = analysistest.begin(ctx)
 
+    # The Javac action tokenizes each flag into individual argv entries, so "--release 25"
+    # reaches the action as ["--release", "25"].
     argv = _javac_action(env).argv
     asserts.true(
         env,
-        "--release 25" in argv,
+        "--release" in argv,
         msg = "kt_javac_options(release = \"25\") should reach the Javac action as --release 25",
+    )
+    asserts.equals(
+        env,
+        expected = "25",
+        actual = argv[argv.index("--release") + 1],
     )
 
     return analysistest.end(env)

--- a/src/test/starlark/internal/jvm/javac_options_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_options_test.bzl
@@ -80,6 +80,20 @@ def _mixed_target_explicit_no_proc_test_impl(ctx):
 
 _mixed_target_explicit_no_proc_test = analysistest.make(_mixed_target_explicit_no_proc_test_impl)
 
+def _release_flag_reaches_javac_test_impl(ctx):
+    env = analysistest.begin(ctx)
+
+    argv = _javac_action(env).argv
+    asserts.true(
+        env,
+        "--release 25" in argv,
+        msg = "kt_javac_options(release = \"25\") should reach the Javac action as --release 25",
+    )
+
+    return analysistest.end(env)
+
+_release_flag_reaches_javac_test = analysistest.make(_release_flag_reaches_javac_test_impl)
+
 def _javac_options_contents():
     write_file(
         name = "javac_flags_java_source",
@@ -98,6 +112,12 @@ def _javac_options_contents():
     kt_javac_options(
         name = "no_proc_javac_options",
         no_proc = True,
+        tags = ["manual"],
+    )
+
+    kt_javac_options(
+        name = "release_25_javac_options",
+        release = "25",
         tags = ["manual"],
     )
 
@@ -133,6 +153,13 @@ def _javac_options_contents():
         tags = ["manual"],
     )
 
+    kt_jvm_library(
+        name = "javac_release_25_library",
+        srcs = ["javac_flags_java_source"],
+        javac_opts = ":release_25_javac_options",
+        tags = ["manual"],
+    )
+
     _no_proc_reaches_javac_test(
         name = "no_proc_reaches_the_javac_action_test",
         target_under_test = ":javac_no_proc_library",
@@ -153,6 +180,11 @@ def _javac_options_contents():
         target_under_test = ":javac_mixed_no_proc_library",
     )
 
+    _release_flag_reaches_javac_test(
+        name = "release_25_reaches_the_javac_action_test",
+        target_under_test = ":javac_release_25_library",
+    )
+
 def javac_options_test_suite(name):
     _javac_options_contents()
 
@@ -163,5 +195,6 @@ def javac_options_test_suite(name):
             ":no_proc_off_by_default_test",
             ":mixed_target_no_proc_test",
             ":mixed_target_explicit_no_proc_test",
+            ":release_25_reaches_the_javac_action_test",
         ],
     )


### PR DESCRIPTION
The kotlinc `jvm_target` already allows `"25"` (added in the toolchain and kotlinc options), but `kt_javac_options.release` caps at `"21"`, so `.java` sources in a `kt_jvm_library` can't target Java 25.

This change:
- Adds `"25"` to the allowed `release` values in `kt_javac_options`
- Adds the `--release 25` flag mapping
- Adds an analysis test verifying the flag reaches the Javac action

This is the last piece needed for full JDK 25 compilation support in rules_kotlin.