### PR TITLE
Honor explicit javac release options

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1047,13 +1047,7 @@ def _run_kt_java_builder_actions(
     ksp_generated_java_src_jars = generated_ksp_src_jars and is_ksp_processor_generating_java(ctx.attr.plugins)
     if srcs.java or generated_kapt_src_jars or srcs.src_jars or ksp_generated_java_src_jars:
         javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
-        javac_opts = javac_options_to_flags(javac_options)
-        javac_opts.extend([
-            flag
-            for plugin in ctx.attr.plugins
-            if JavacOptions in plugin
-            for flag in javac_options_to_flags(plugin[JavacOptions])
-        ])
+        javac_opts = []
 
         # Kotlin takes care of annotation processing. Note that JavaBuilder "discovers"
         # annotation processors in `deps` also.
@@ -1074,6 +1068,16 @@ def _run_kt_java_builder_actions(
                 javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target, toolchains.java.java_runtime.version))
             else:
                 javac_opts.extend(_utils.javac_jvm_target_flags(jvm_target))
+
+        # JavaBuilder gives later --release/-source/-target flags precedence. Keep explicit javac
+        # options after the flags derived from the Kotlin target so an explicit release is honored.
+        javac_opts.extend(javac_options_to_flags(javac_options))
+        javac_opts.extend([
+            flag
+            for plugin in ctx.attr.plugins
+            if JavacOptions in plugin
+            for flag in javac_options_to_flags(plugin[JavacOptions])
+        ])
 
         # Compile the Java half with the same warning mode as the kotlin part, unless the javac
         # options (or a plugin's) already set one: a single `warn` value governs the whole target.

--- a/src/test/starlark/internal/jvm/javac_options_test.bzl
+++ b/src/test/starlark/internal/jvm/javac_options_test.bzl
@@ -96,6 +96,17 @@ def _release_flag_reaches_javac_test_impl(ctx):
         expected = "25",
         actual = argv[argv.index("--release") + 1],
     )
+    release_index = argv.index("--release")
+    target_flag_indices = [
+        i
+        for i, arg in enumerate(argv)
+        if arg in ["-source", "-target"]
+    ]
+    asserts.true(
+        env,
+        release_index > max(target_flag_indices),
+        msg = "--release 25 must follow generated -source/-target flags so JavaBuilder keeps it",
+    )
 
     return analysistest.end(env)
 


### PR DESCRIPTION
## Summary

- Emit derived JVM target flags before explicit javac options so an explicit release is honored by JavaBuilder.
- Add regression coverage for kt_javac_options(release = "25").

## Why

Before this change, JavaBuilder received --release 25 followed by generated -source/-target flags and silently used the latter. The new regression test fails on master and passes with this fix.

## Testing

- bazel test //src/test/starlark/internal/jvm:javac_options_tests
- bazel test //src/test/starlark/internal/jvm:javac_jvm_target_tests //src/test/starlark/internal/jvm:javac_warn_tests //src/test/starlark/internal/jvm:javac_encoding_tests
- bazel build //src/test/starlark/internal/jvm:javac_release_25_library
- Verified the generated class file is Java 25 (major version 69).
- buildifier -mode=check passed.