### PR TITLE
Update Bazel CI rules and fix host RBE toolchains

### DIFF
--- a/.bazelci/tests.yml
+++ b/.bazelci/tests.yml
@@ -94,10 +94,15 @@ tasks:
       - "//src/test/kotlin/io/bazel/kotlin:KotlinJvmBasicAssertionTest"
     test_flags:
       - "--strategy=KotlinCompile=remote"
+      - "--action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"
   stardoc:
     <<: *common
     name: Stardoc api documentation
     platform: rbe_ubuntu2404
+    build_flags:
+      - "--action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"
+    test_flags:
+      - "--action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"
     build_targets:
       - //docs:stardoc
     test_targets:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,7 +66,7 @@ register_toolchains("//kotlin/internal:default_toolchain")
 
 bazel_dep(name = "rules_jvm_external", version = "7.1")
 
-bazel_dep(name = "bazel_ci_rules", version = "2.0.0", dev_dependency = True)
+bazel_dep(name = "bazel_ci_rules", version = "2.1.1", dev_dependency = True)
 
 rbe = use_extension("@bazel_ci_rules//:rbe_config.bzl", "rbe_config_extension", dev_dependency = True)
 rbe.config(


### PR DESCRIPTION
## Summary

Update `bazel_ci_rules` from 2.0.0 to 2.1.1 and keep the RBE CI configuration working with the newer host-mode generator.

## Why

The Renovate update in [#1689](https://github.com/bazel-contrib/rules_kotlin/pull/1689) exposed an interaction between the upstream Bazel CI runner and `bazel_ci_rules` 2.1.x. The runner passes `--action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1`; the host-mode RBE generator inherits that value, creates a no-op `local_config_cc`, and then fails to resolve the C++ toolchain.

## Changes

- Bump `bazel_ci_rules` to 2.1.1.
- Override `BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN` to `0` for the Ubuntu RBE and Stardoc jobs.

## Validation

The failure and fix were reproduced in the Ubuntu 24.04 CI container with Bazel 8.4.2. With the override, `@buildkite_config//cc:toolchain` generates and builds successfully.

This PR supersedes Renovate PR [#1689](https://github.com/bazel-contrib/rules_kotlin/pull/1689).
