### PR TITLE
Update default Kotlin version to 2.4

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -116,7 +116,7 @@ _kt_toolchain = rule(
     attrs = {
         "api_version": attr.string(
             doc = "this is the -api_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html).",
-            default = "2.1",
+            default = "2.4",
             values = [
                 "1.1",
                 "1.2",
@@ -298,7 +298,7 @@ _kt_toolchain = rule(
         ),
         "language_version": attr.string(
             doc = "this is the -language_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html)",
-            default = "2.1",
+            default = "2.4",
             values = [
                 "1.1",
                 "1.2",

--- a/src/test/starlark/internal/jvm/kotlinc_options_test.bzl
+++ b/src/test/starlark/internal/jvm/kotlinc_options_test.bzl
@@ -65,10 +65,10 @@ def _toolchain_versions_by_default_test_impl(ctx):
     argv = _kotlin_compile_action(env).argv
 
     # Without kotlinc options the worker channel carries the toolchain-wide versions.
-    asserts.equals(env, expected = "2.1", actual = _value_of(env, argv, "--kotlin_api_version"))
+    asserts.equals(env, expected = "2.4", actual = _value_of(env, argv, "--kotlin_api_version"))
     asserts.equals(
         env,
-        expected = "2.1",
+        expected = "2.4",
         actual = _value_of(env, argv, "--kotlin_language_version"),
     )
 


### PR DESCRIPTION
Use the latest API and language versions supported by the bundled Kotlin 2.4.10 compiler.
