### PR TITLE
Compile the java half of a target against the full Kotlin output

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1028,7 +1028,8 @@ def _run_kt_java_builder_actions(
         compile_jars.append(kt_compile_jar)
         output_jars.append(kt_runtime_jar)
         if not annotation_processors or not srcs.kt:
-            kt_stubs_for_java.append(JavaInfo(compile_jar = kt_compile_jar, output_jar = kt_runtime_jar, neverlink = True))
+            # Compile the java half of this target against the FULL Kotlin output, not the ABI;
+            kt_stubs_for_java.append(JavaInfo(compile_jar = kt_runtime_jar, output_jar = kt_runtime_jar, neverlink = True))
 
         kt_java_info = JavaInfo(
             output_jar = kt_runtime_jar,


### PR DESCRIPTION
A file-private Kotlin class compiles to package-private bytecode, which may be referenced from java code in the same target. These file-private Kotlin classes are stripped from ABI jar, if "removePrivateClasses" is set. Compiling java half of the target against the ABI jar leads to compilation errors.