### PR TITLE
Upgrade Kotlin to 2.4.20

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -694,7 +694,7 @@ Call this in the WORKSPACE file to setup the Kotlin rules.
 | <a id="kotlin_repositories-is_bzlmod"></a>is_bzlmod |  <p align="center"> - </p>   |  `False` |
 | <a id="kotlin_repositories-compiler_repository_name"></a>compiler_repository_name |  for the kotlinc compiler repository.   |  `"com_github_jetbrains_kotlin"` |
 | <a id="kotlin_repositories-ksp_repository_name"></a>ksp_repository_name |  <p align="center"> - </p>   |  `"com_github_google_ksp"` |
-| <a id="kotlin_repositories-compiler_release"></a>compiler_release |  version provider from versions.bzl.   |  `struct(sha256 = "473dd66c7a3ef4b182065b3da670466c1bf2773a9dbb0ed8b33a39fe9d4f876d", url_templates = ["https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip"], version = "2.4.10")` |
+| <a id="kotlin_repositories-compiler_release"></a>compiler_release |  version provider from versions.bzl.   |  `struct(sha256 = "59e9ca74c7904ef2c122b12114937673ccce68de820a663f0ed66ccf8799e0b7", url_templates = ["https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip"], version = "2.4.20")` |
 | <a id="kotlin_repositories-ksp_compiler_release"></a>ksp_compiler_release |  (internal) version provider from versions.bzl.   |  `struct(sha256 = "b0e7666caf7afb634350ca64af9a88c3bd3e04df393fd33dbf430daaf285c6b3", url_templates = ["https://github.com/google/ksp/releases/download/{version}/artifacts.zip"], version = "2.3.11")` |
 | <a id="kotlin_repositories-btapi_impl_releases"></a>btapi_impl_releases |  the Build Tools API implementation records, a dict of repository name to a record built with btapi_impl_version. The record of the current release is always created as @btapi_impl unless the dict replaces it.   |  `None` |
 

--- a/examples/jetpack_compose/MODULE.bazel
+++ b/examples/jetpack_compose/MODULE.bazel
@@ -30,7 +30,7 @@ maven.install(
     name = "maven_rules_kotlin_example",
     aar_import_bzl_label = "@rules_android//rules:rules.bzl",
     artifacts = [
-        "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:2.4.10",
+        "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:2.4.20",
         "androidx.core:core-ktx:1.15.0",
         "androidx.appcompat:appcompat:1.7.0",
         "androidx.activity:activity-compose:1.7.0",

--- a/examples/jetpack_compose/maven_install.json
+++ b/examples/jetpack_compose/maven_install.json
@@ -11,7 +11,7 @@
     "androidx.core:core-ktx": -1348396836,
     "androidx.lifecycle:lifecycle-common": 234331668,
     "androidx.lifecycle:lifecycle-runtime": -526123229,
-    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable": 212040376,
+    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable": 15526871,
     "repositories": 1670674627
   },
   "__RESOLVED_ARTIFACTS_HASH": {
@@ -183,8 +183,8 @@
     "androidx.viewpager:viewpager:jar:sources": -1999416519,
     "com.google.guava:listenablefuture": -1728764445,
     "com.google.guava:listenablefuture:jar:sources": 428207214,
-    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable": 412466121,
-    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:jar:sources": 987141179,
+    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable": 257751711,
+    "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable:jar:sources": 1251134462,
     "org.jetbrains.kotlin:kotlin-stdlib": 1646588665,
     "org.jetbrains.kotlin:kotlin-stdlib-common": 2031482529,
     "org.jetbrains.kotlin:kotlin-stdlib-common:jar:sources": -50887075,
@@ -1154,10 +1154,10 @@
     },
     "org.jetbrains.kotlin:kotlin-compose-compiler-plugin-embeddable": {
       "shasums": {
-        "jar": "07edff96c6196c5354caa275b748616794cc8883af02e380d091d221f02bdc80",
-        "sources": "c8bc960e0ce21534127e638d0bdd750bc64ec391db0e8333665ea0dad48e0139"
+        "jar": "e6fc101fd0b8592911de57f96a75b09e0b6158eaccbc71ddd6ca82e05e0386a2",
+        "sources": "bee47d61e35cb6b5c91e1d3d6bcc589bb9510f1c1aa0c64943784cc133312b16"
       },
-      "version": "2.4.10"
+      "version": "2.4.20"
     },
     "org.jetbrains.kotlin:kotlin-stdlib": {
       "shasums": {
@@ -1895,7 +1895,6 @@
       "androidx.compose.compiler.plugins.kotlin",
       "androidx.compose.compiler.plugins.kotlin.analysis",
       "androidx.compose.compiler.plugins.kotlin.inference",
-      "androidx.compose.compiler.plugins.kotlin.k1",
       "androidx.compose.compiler.plugins.kotlin.k2",
       "androidx.compose.compiler.plugins.kotlin.lower",
       "androidx.compose.compiler.plugins.kotlin.lower.hiddenfromobjc"

--- a/src/main/kotlin/io/bazel/kotlin/plugin/SkipCodeGen.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/SkipCodeGen.kt
@@ -31,7 +31,10 @@ import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 /**
  *  SkipCodeGen registers an extension to skip code generation. Must be the last compiler plugin.
  */
-@OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
+@OptIn(
+  org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class,
+  org.jetbrains.kotlin.K1Deprecation::class,
+)
 class SkipCodeGen : CompilerPluginRegistrar() {
   override val pluginId: String = COMPILER_PLUGIN_ID
 

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
@@ -26,6 +26,7 @@ class JdepsGenComponentRegistrar : CompilerPluginRegistrar() {
     }
   }
 
+  @OptIn(org.jetbrains.kotlin.K1Deprecation::class)
   private fun ExtensionStorage.registerForK1(configuration: CompilerConfiguration) {
     // Capture all types referenced by the compiler for this module and look up the jar from which
     // they were loaded from

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -64,6 +64,7 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
  * @param project the current compilation project
  * @param configuration the current compilation configuration
  */
+@OptIn(org.jetbrains.kotlin.K1Deprecation::class)
 class JdepsGenExtension(
   configuration: CompilerConfiguration,
 ) : BaseJdepsGenExtension(configuration),

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/expression/ResolvedQualifierChecker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/expression/ResolvedQualifierChecker.kt
@@ -13,7 +13,7 @@ internal class ResolvedQualifierChecker(
 ) : FirResolvedQualifierChecker(MppCheckerKind.Common) {
   context(context: CheckerContext, reporter: DiagnosticReporter)
   override fun check(expression: FirResolvedQualifier) {
-    expression.symbol?.let {
+    expression.qualifierSymbol?.let {
       classUsageRecorder.recordClass(it, context)
     }
   }

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -23,7 +23,7 @@ def _use_repository(rule, name, version, **kwargs):
 # The Kotlin compiler release train: the CLI distribution, the Build Tools API jar, and the Build
 # Tools API implementation record ship together under this one version. Bump them together; each
 # entry keeps its own per-artifact sha256.
-_KOTLIN_CURRENT_RELEASE = "2.4.10"
+_KOTLIN_CURRENT_RELEASE = "2.4.20"
 
 versions = struct(
     # IMPORTANT! rules_kotlin does not use the bazel_skylib unittest in production
@@ -76,7 +76,7 @@ versions = struct(
         url_templates = [
             "https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip",
         ],
-        sha256 = "473dd66c7a3ef4b182065b3da670466c1bf2773a9dbb0ed8b33a39fe9d4f876d",
+        sha256 = "59e9ca74c7904ef2c122b12114937673ccce68de820a663f0ed66ccf8799e0b7",
     ),
     KSP_CURRENT_COMPILER_PLUGIN_RELEASE = version(
         version = "2.3.11",
@@ -92,7 +92,7 @@ versions = struct(
         url_templates = [
             "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/{version}/kotlin-build-tools-api-{version}.jar",
         ],
-        sha256 = "3953d283e7710c990672e403a87df393d9726a9bf3e172194ebb5c33e062fcb0",
+        sha256 = "47a622dce7231b1916334b69a00bc1094adf6577e6492f9f06b3d9c2450fe459",
     ),
     # The Build Tools API implementation of the current release and the embeddable compiler family
     # it loads: the Maven-published kotlinc build whose bundled third-party packages are shaded
@@ -100,14 +100,14 @@ versions = struct(
     # Gradle/Maven consumption are compiled against. The repository @btapi_impl is built from it.
     BTAPI_IMPL_CURRENT_RELEASE = btapi_impl_version(
         version = _KOTLIN_CURRENT_RELEASE,
-        build_tools_impl_sha256 = "4a32f63522ef4726afbdee1783f05698499abc7a5ecade3a6cafa3e4074562ee",
-        compiler_sha256 = "9309638a2ee03e6bde9ef4b7444055a94b84ab906563675d71ff9aecb64da913",
-        annotation_processing_sha256 = "9b48f56404afc57c8498c7a9a9e678ea5954693e9550b185573de46fba22052e",
-        jvm_abi_gen_sha256 = "baaa13b3c428b2a1ea81c0e7ff4474779735fe47e7fc3bca8ff79793671f0e60",
-        stdlib_sha256 = "4ec0293bc3751423b203f1d8493251c57c42e73eb6377a6b8560d0974ff0a6df",
-        reflect_sha256 = "25a1aef7454d46548ecaaf51021b0e52e38141a62ed75af124da109b7324c4e5",
-        daemon_client_sha256 = "a3d1a5854fd92766de1ca37ff003a822d3da2039902008384dd1f7375f3d5cf9",
-        script_runtime_sha256 = "f4a5b30c2fdfbe386b097101b7989dbeea3743c06396136664784e08e15c6899",
+        build_tools_impl_sha256 = "68fb6f266a66463a1ba3ddb99b96e5eb202ab19a5ca4e3b56dad5eec62641c7d",
+        compiler_sha256 = "cf97161430683fb9af96dc6a7017ffae1fe8737b80d12eee11f2fe3e76f8ded8",
+        annotation_processing_sha256 = "b1462810aa9b3b2f2a93339f1d0729fd8081690d3d5aae194aff3fb5b026a79e",
+        jvm_abi_gen_sha256 = "cf4a7ab4b94d1e508bfa1ab6f6dd66dbde4b35f608c3ab658f9ba338d518dbe1",
+        stdlib_sha256 = "2226de463d309d4a5500a481320b3dea515a6981dcae1def531fbc158884e25f",
+        reflect_sha256 = "b4aac2a4686ffdc110602ce153e4a90ffd7f37fa86fcca9d3b3aa39c08f8c2fc",
+        daemon_client_sha256 = "89532756fc258fbde177cf1654383f15127c048d17525141c922e9aa0969d997",
+        script_runtime_sha256 = "fc5a19df78be445d84e8352e0d01098a6a8181324aa50c6f7bf850338e81e1b4",
     ),
     RULES_ANDROID = version(
         version = "0.7.0",


### PR DESCRIPTION
Upgrade the default Kotlin compiler, Build Tools API and runtime, and Compose compiler plugin from 2.4.10 to 2.4.20. Update the checksums for the embeddable compiler, kapt, ABI plugin, and supporting Kotlin jars; repin Compose and regenerate documentation.

Opt into the remaining K1 APIs and use the renamed FIR qualifier field. The Build Tools runtime added in #1724 uses the original Maven implementation with the embeddable compiler, so this upgrade needs no additional JarJar rule or repackaged implementation jar.

Validation on macOS arm64 with Bazel 9.2.0:
- All 165 source test targets pass uncached, including all 10 Build Tools compilation test methods.
- Six packaged-release integration scenarios pass with both compiler backends: trivial, compiler plugins, KSP, associates, multiplex, and path mapping.
- The multiplex scenario passed on retry using the existing verified download cache after its initial run hit a GitHub DNS failure fetching KSP.
- Documentation generation, Buildifier, and whitespace checks pass.
- Verified the downloaded runtime artifacts and the release archive's version pins.

Release: https://github.com/JetBrains/kotlin/releases/tag/v2.4.20
