### PR TITLE
Update KSP to 2.3.12

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -695,7 +695,7 @@ Call this in the WORKSPACE file to setup the Kotlin rules.
 | <a id="kotlin_repositories-compiler_repository_name"></a>compiler_repository_name |  for the kotlinc compiler repository.   |  `"com_github_jetbrains_kotlin"` |
 | <a id="kotlin_repositories-ksp_repository_name"></a>ksp_repository_name |  <p align="center"> - </p>   |  `"com_github_google_ksp"` |
 | <a id="kotlin_repositories-compiler_release"></a>compiler_release |  version provider from versions.bzl.   |  `struct(sha256 = "473dd66c7a3ef4b182065b3da670466c1bf2773a9dbb0ed8b33a39fe9d4f876d", url_templates = ["https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip"], version = "2.4.10")` |
-| <a id="kotlin_repositories-ksp_compiler_release"></a>ksp_compiler_release |  (internal) version provider from versions.bzl.   |  `struct(sha256 = "b0e7666caf7afb634350ca64af9a88c3bd3e04df393fd33dbf430daaf285c6b3", url_templates = ["https://github.com/google/ksp/releases/download/{version}/artifacts.zip"], version = "2.3.11")` |
+| <a id="kotlin_repositories-ksp_compiler_release"></a>ksp_compiler_release |  (internal) version provider from versions.bzl.   |  `struct(sha256 = "31e83f087c3e822d16d93b2fd240769872ba1fad26e7f3b5dfb3f71513e7399f", url_templates = ["https://github.com/google/ksp/releases/download/{version}/artifacts.zip"], version = "2.3.12")` |
 | <a id="kotlin_repositories-btapi_impl_releases"></a>btapi_impl_releases |  the Build Tools API implementation records, a dict of repository name to a record built with btapi_impl_version. The record of the current release is always created as @btapi_impl unless the dict replaces it.   |  `None` |
 
 

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -79,11 +79,11 @@ versions = struct(
         sha256 = "473dd66c7a3ef4b182065b3da670466c1bf2773a9dbb0ed8b33a39fe9d4f876d",
     ),
     KSP_CURRENT_COMPILER_PLUGIN_RELEASE = version(
-        version = "2.3.11",
+        version = "2.3.12",
         url_templates = [
             "https://github.com/google/ksp/releases/download/{version}/artifacts.zip",
         ],
-        sha256 = "b0e7666caf7afb634350ca64af9a88c3bd3e04df393fd33dbf430daaf285c6b3",
+        sha256 = "31e83f087c3e822d16d93b2fd240769872ba1fad26e7f3b5dfb3f71513e7399f",
     ),
     # Starting with Kotlin 2.4.0 the Build Tools API interfaces are no longer bundled in
     # kotlin-compiler.jar, so they must be provided as a separate jar.


### PR DESCRIPTION
Update the default KSP release from 2.3.11 to [2.3.12](https://github.com/google/ksp/releases/tag/2.3.12), with the SHA-256 computed from the release's `artifacts.zip`. Regenerate the documented default to match.

Validation:
- `bazel test //src/... --jobs=6` — all 165 tests passed after rebasing onto `593bfa2c` (PR #1724).
- `bazel run //docs:write_docs --jobs=6`
- `bazel run //:buildifier.fix --jobs=6`
- `bazel run //:coffee_app --jobs=4` from `examples/ksp` — built and ran successfully with Dagger, Moshi, AutoService, and generated sources.

Only the KSP coffee example was run; the full example matrix was skipped.
