### PR TITLE
Invalidate BTAPI compiler caches when runtime jars change

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
@@ -20,6 +20,7 @@ package io.bazel.kotlin.builder.tasks.jvm
 import io.bazel.kotlin.builder.utils.ArgMap
 import io.bazel.kotlin.builder.utils.ArgMaps
 import io.bazel.kotlin.builder.utils.Flag
+import io.bazel.kotlin.builder.utils.fingerprintOf
 import io.bazel.worker.Status
 import io.bazel.worker.Work
 import io.bazel.worker.WorkerContext
@@ -30,8 +31,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
-import java.security.DigestInputStream
-import java.security.MessageDigest
 import java.util.GregorianCalendar
 import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarEntry
@@ -91,7 +90,7 @@ class Ksp2Task : Work {
 
     fun getKspClassLoader(processorClasspath: List<String>): URLClassLoader {
       val cacheKey = processorClasspath.sorted().joinToString(File.pathSeparator)
-      val fingerprint = fingerprintOf(processorClasspath)
+      val fingerprint = fingerprintOf(processorClasspath.sorted())
       return classLoaderCache
         .compute(cacheKey) { _, existing ->
           if (existing != null && existing.fingerprint == fingerprint) {
@@ -114,18 +113,6 @@ class Ksp2Task : Work {
     fun clearKspClassLoaderCacheForTesting() {
       classLoaderCache.values.forEach { runCatching { it.classLoader.close() } }
       classLoaderCache.clear()
-    }
-
-    fun fingerprintOf(classpath: List<String>): String {
-      val sortedPaths = classpath.sorted()
-      val digest = MessageDigest.getInstance("SHA-256")
-      for (path in sortedPaths) {
-        val file = File(path)
-        digest.update(path.toByteArray(StandardCharsets.UTF_8))
-        digest.update(file.length().toString().toByteArray(StandardCharsets.UTF_8))
-        DigestInputStream(Files.newInputStream(file.toPath()), digest).use { it.readAllBytes() }
-      }
-      return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     // Fixed epoch (1980-01-01 00:00:00 UTC) for reproducible jar timestamps.

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/btapi/BtapiTaskExecutor.kt
@@ -37,6 +37,7 @@ import io.bazel.kotlin.builder.tasks.jvm.stubs
 import io.bazel.kotlin.builder.tasks.toRuntime
 import io.bazel.kotlin.builder.toolchain.CompilationStatusException
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
+import io.bazel.kotlin.builder.utils.fingerprintOf
 import io.bazel.kotlin.compiler.CompilationUnit
 import io.bazel.kotlin.compiler.CompilerConfiguration
 import io.bazel.kotlin.compiler.CompilerPluginSpec
@@ -63,7 +64,12 @@ class BtapiTaskExecutor(
   private val btapiClassLoader: ClassLoader,
 ) : JvmTaskExecutor {
   /** api_impl_classpath -> compiler invoker map */
-  private val invokers = ConcurrentHashMap<List<String>, KotlinBtapiCompiler>()
+  private val invokers = ConcurrentHashMap<List<String>, CacheEntry>()
+
+  private data class CacheEntry(
+    val compiler: KotlinBtapiCompiler,
+    val fingerprint: String,
+  )
 
   private data class PluginDescriptor(
     override val id: String,
@@ -99,7 +105,7 @@ class BtapiTaskExecutor(
     val btapiRuntime =
       task.info.toolchainInfo.btapi
         .toRuntime()
-    val compiler = invokers.computeIfAbsent(btapiRuntime.apiImplClasspath, ::loadCompilerInvoker)
+    val compiler = getCompilerInvoker(btapiRuntime.apiImplClasspath)
     val preprocessedTask =
       task
         .preProcessingSteps(context)
@@ -153,6 +159,19 @@ class BtapiTaskExecutor(
         }
       }
     }
+  }
+
+  fun getCompilerInvoker(classpath: List<String>): KotlinBtapiCompiler {
+    val fingerprint = fingerprintOf(classpath)
+    return invokers
+      .compute(classpath) { _, existing ->
+        if (existing != null && existing.fingerprint == fingerprint) {
+          existing
+        } else {
+          CacheEntry(loadCompilerInvoker(classpath), fingerprint)
+        }
+      }!!
+      .compiler
   }
 
   private fun loadCompilerInvoker(classpath: List<String>): KotlinBtapiCompiler {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/ClasspathFingerprint.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/ClasspathFingerprint.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.bazel.kotlin.builder.utils
+
+import java.io.File
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+/** Fingerprints jar paths and contents in classpath order, without buffering whole jars. */
+fun fingerprintOf(classpath: List<String>): String {
+  val digest = MessageDigest.getInstance("SHA-256")
+  for (path in classpath) {
+    val file = File(path)
+    digest.update(path.toByteArray(StandardCharsets.UTF_8))
+    digest.update(file.length().toString().toByteArray(StandardCharsets.UTF_8))
+    DigestInputStream(Files.newInputStream(file.toPath()), digest).use {
+      it.transferTo(OutputStream.nullOutputStream())
+    }
+  }
+  return digest.digest().joinToString("") { "%02x".format(it) }
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -152,6 +152,17 @@ kt_rules_test(
 )
 
 kt_rules_test(
+    name = "BtapiRuntimeCacheTest",
+    srcs = ["BtapiRuntimeCacheTest.kt"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
+        "//src/main/kotlin/io/bazel/kotlin/compiler",
+        "@kotlin_rules_maven_test//:com_google_truth_truth",
+        "@kotlin_rules_maven_test//:junit_junit",
+    ],
+)
+
+kt_rules_test(
     name = "BtapiRuntimeFlagsValidationTest",
     srcs = ["BtapiRuntimeFlagsValidationTest.kt"],
     deps = [
@@ -176,6 +187,7 @@ kt_rules_test(
 test_suite(
     name = "tasks_tests",
     tests = [
+        ":BtapiRuntimeCacheTest",
         ":BtapiRuntimeFlagsValidationTest",
         ":JdepsMergerTest",
         ":JdepsParserTest",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BtapiRuntimeCacheTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BtapiRuntimeCacheTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.bazel.kotlin.builder.tasks
+
+import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.builder.tasks.jvm.btapi.BtapiTaskExecutor
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class BtapiRuntimeCacheTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
+  // The invoker loads the compiler runtime lazily; only its identity matters in these tests.
+  private val executor = BtapiTaskExecutor(javaClass.classLoader)
+
+  @Test
+  fun testReusesUnchangedRuntimeAndInvalidatesChangedContents() {
+    val jar = tmp.newFile("compiler.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    val classpath = listOf(jar.absolutePath)
+    val first = executor.getCompilerInvoker(classpath)
+    assertThat(executor.getCompilerInvoker(classpath)).isSameInstanceAs(first)
+
+    val timestamp = jar.lastModified()
+    jar.writeBytes(byteArrayOf(4, 5, 6))
+    check(jar.setLastModified(timestamp))
+    val replacement = executor.getCompilerInvoker(classpath)
+    assertThat(replacement).isNotSameInstanceAs(first)
+    assertThat(executor.getCompilerInvoker(classpath)).isSameInstanceAs(replacement)
+  }
+
+  @Test
+  fun testClasspathOrderSelectsDifferentRuntime() {
+    val first = tmp.newFile("first.jar").apply { writeBytes(byteArrayOf(1)) }
+    val second = tmp.newFile("second.jar").apply { writeBytes(byteArrayOf(2)) }
+    val classpath = listOf(first.absolutePath, second.absolutePath)
+    assertThat(executor.getCompilerInvoker(classpath.reversed()))
+      .isNotSameInstanceAs(executor.getCompilerInvoker(classpath))
+  }
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
@@ -20,10 +20,10 @@ import com.google.common.truth.Truth.assertThat
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2EntryPoint
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.Ksp2Flags
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.clearKspClassLoaderCacheForTesting
-import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.fingerprintOf
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.getKspClassLoader
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.parseKspOptions
 import io.bazel.kotlin.builder.utils.ArgMap
+import io.bazel.kotlin.builder.utils.fingerprintOf
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -243,7 +243,9 @@ class Ksp2TaskTest {
     val classpath = listOf(jar.absolutePath)
 
     val firstClassLoader = getKspClassLoader(classpath)
-    jar.writeBytes(byteArrayOf(4, 5, 6, 7))
+    val timestamp = jar.lastModified()
+    jar.writeBytes(byteArrayOf(4, 5, 6))
+    check(jar.setLastModified(timestamp))
     val secondClassLoader = getKspClassLoader(classpath)
 
     assertThat(secondClassLoader).isNotSameInstanceAs(firstClassLoader)
@@ -262,7 +264,9 @@ class Ksp2TaskTest {
     val classpath = listOf(jar.absolutePath)
     val before = fingerprintOf(classpath)
 
-    jar.writeBytes(byteArrayOf(4, 5, 6, 7))
+    val timestamp = jar.lastModified()
+    jar.writeBytes(byteArrayOf(4, 5, 6))
+    check(jar.setLastModified(timestamp))
     val after = fingerprintOf(classpath)
 
     assertThat(after).isNotEqualTo(before)


### PR DESCRIPTION
BTAPI cached compiler invokers by jar paths, so replacing a custom runtime jar at the same path kept using the old compiler. Share KSP2's SHA-256 fingerprinting of jar paths, sizes, and contents, and replace BTAPI cache entries when that fingerprint changes.

BTAPI retains classpath order, while KSP2 keeps its existing order-insensitive cache behavior. Hashing streams jar contents instead of allocating a buffer for each entire jar.

Validation:
- Confirmed the new regression test fails with the old cache behavior.
- `bazel test //src/...`: all 166 tests passed, including runtime replacement with unchanged file size and timestamp, classpath ordering, and BTAPI compilation tests.
- `bazel run //docs:write_docs` and `bazel run //:buildifier.fix`: passed with no generated changes.

Follow-up to #1724.
