### PR TITLE
Support pluggable Android local test coverage pipelines

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,9 @@ common --incompatible_autoload_externally=
 common --java_runtime_version=remotejdk_17
 common --tool_java_runtime_version=remotejdk_17
 
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17
+
 build --test_output=all
 build --verbose_failures
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,16 @@ bazel_dep(name = "rules_java", version = "8.9.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_android", version = "0.7.3")
 
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)
+
 remote_android_extensions = use_extension(
     "@rules_android//bzlmod_extensions:android_extensions.bzl",
     "remote_android_tools_extensions",

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -27,3 +27,6 @@ build:android_worker \
   --strategy=JavaSourceJar=remote,local \
   --strategy=Turbine=remote,local \
   --strategy=PackageAndroidResources=local
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/android/MODULE.bazel
+++ b/examples/android/MODULE.bazel
@@ -40,3 +40,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/anvil/.bazelrc
+++ b/examples/anvil/.bazelrc
@@ -1,2 +1,5 @@
 common --java_runtime_version=remotejdk_21
 common --tool_java_runtime_version=remotejdk_21
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/anvil/MODULE.bazel
+++ b/examples/anvil/MODULE.bazel
@@ -74,3 +74,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/deps/.bazelrc
+++ b/examples/deps/.bazelrc
@@ -7,3 +7,6 @@ common --toolchain_resolution_debug=.*
 # Required for abseil-cpp which requires C++17
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/deps/MODULE.bazel
+++ b/examples/deps/MODULE.bazel
@@ -29,3 +29,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -14,3 +14,6 @@ common --tool_java_runtime_version=remotejdk_17
 # Required for abseil-cpp which requires C++17
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/jetpack_compose/MODULE.bazel
+++ b/examples/jetpack_compose/MODULE.bazel
@@ -52,3 +52,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/plugin/.bazelrc
+++ b/examples/plugin/.bazelrc
@@ -1,2 +1,5 @@
 common --java_runtime_version=remotejdk_21
 common --tool_java_runtime_version=remotejdk_21
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/plugin/MODULE.bazel
+++ b/examples/plugin/MODULE.bazel
@@ -26,3 +26,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/kotlin/internal/jvm/kt_android_local_test.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test.bzl
@@ -55,11 +55,24 @@ _ATTRS = _utils.add_dicts(_BASE_ATTRS, _attrs.runnable_common_attr, {
     ),
 })
 
-kt_android_local_test = _make_rule(
-    implementation = _kt_android_local_test_impl,
-    attrs = _ATTRS,
-    additional_toolchains = [
-        _TOOLCHAIN_TYPE,
-        _JAVA_RUNTIME_TOOLCHAIN_TYPE,
-    ],
-)
+def make_rule(attrs = {}, implementation = _kt_android_local_test_impl, additional_toolchains = []):
+    """Creates a Kotlin Android local test rule with a custom processing pipeline.
+
+    Args:
+      attrs: Additional attributes or overrides for the Kotlin test attributes.
+      implementation: Rule implementation running the processing pipeline.
+      additional_toolchains: Toolchains required by custom processors.
+
+    Returns:
+      A test rule with the Kotlin compilation attributes and toolchains.
+    """
+    return _make_rule(
+        implementation = implementation,
+        attrs = _utils.add_dicts(_ATTRS, attrs),
+        additional_toolchains = [
+            _TOOLCHAIN_TYPE,
+            _JAVA_RUNTIME_TOOLCHAIN_TYPE,
+        ] + additional_toolchains,
+    )
+
+kt_android_local_test = make_rule()

--- a/kotlin/internal/jvm/kt_android_local_test_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test_impl.bzl
@@ -110,7 +110,28 @@ def _process_resources(ctx, java_package, manifest_ctx, **_unused_sub_ctxs):
         value = resources_ctx,
     )
 
-def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
+def _process_coverage(ctx, **_unused_sub_ctxs):
+    """Selects the Kotlin toolchain's coverage runtime independently of compilation."""
+    deps = []
+    if ctx.configuration.coverage_enabled:
+        deps.append(ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner)
+        java_start_class = _JACOCOCO_CLASS
+        coverage_start_class = ctx.attr.main_class
+    else:
+        java_start_class = ctx.attr.main_class
+        coverage_start_class = None
+
+    return _ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = deps,
+            java_start_class = java_start_class,
+            coverage_start_class = coverage_start_class,
+            additional_jvm_flags = [],
+        ),
+    )
+
+def _process_jvm(ctx, resources_ctx, coverage_ctx, **_unused_sub_ctxs):
     """Custom JvmProcessor that handles Kotlin compilation
     """
     _compile.verify_associates_not_duplicated_in_deps(deps = getattr(ctx.attr, "deps", []), associate_deps = getattr(ctx.attr, "associates", []))
@@ -120,16 +141,9 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
     deps = (
         [_get_android_toolchain(ctx).testsupport] +
         getattr(ctx.attr, "associates", []) +
-        getattr(ctx.attr, "deps", [])
+        getattr(ctx.attr, "deps", []) +
+        coverage_ctx.deps
     )
-
-    if ctx.configuration.coverage_enabled:
-        deps.append(ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner)
-        java_start_class = _JACOCOCO_CLASS
-        coverage_start_class = ctx.attr.main_class
-    else:
-        java_start_class = ctx.attr.main_class
-        coverage_start_class = None
 
     # Setup the compile action.
     providers = _compile.kt_jvm_produce_output_jar_actions(
@@ -173,7 +187,7 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
         runfiles.append(filtered_jdeps)
 
     # Append the security manager override
-    jvm_flags = []
+    jvm_flags = list(coverage_ctx.additional_jvm_flags)
     java_runtime = ctx.toolchains[_JAVA_RUNTIME_TOOLCHAIN_TYPE].java_runtime
 
     _java_runtime_version = getattr(java_runtime, "version", 0)
@@ -186,8 +200,8 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
             java_info = java_info,
             providers = providers,
             deps = deps,
-            java_start_class = java_start_class,
-            coverage_start_class = coverage_start_class,
+            java_start_class = coverage_ctx.java_start_class,
+            coverage_start_class = coverage_ctx.coverage_start_class,
             android_properties_file = ctx.file.robolectric_properties_file.short_path,
             additional_jvm_flags = jvm_flags,
         ),
@@ -197,6 +211,7 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
 PROCESSORS = _processing_pipeline.replace(
     _BASE_PROCESSORS,
     ResourceProcessor = _process_resources,
+    CoverageProcessor = _process_coverage,
     JvmProcessor = _process_jvm,
 )
 

--- a/src/test/starlark/android_local_test/BUILD.bazel
+++ b/src/test/starlark/android_local_test/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":coverage_test.bzl", "coverage_test_suite")
+
+coverage_test_suite(name = "coverage_tests")

--- a/src/test/starlark/android_local_test/ExampleTest.kt
+++ b/src/test/starlark/android_local_test/ExampleTest.kt
@@ -1,0 +1,16 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.example
+
+class ExampleTest

--- a/src/test/starlark/android_local_test/coverage_test.bzl
+++ b/src/test/starlark/android_local_test/coverage_test.bzl
@@ -1,0 +1,139 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis tests and a make_rule prototype for custom coverage runtimes."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_android//rules:java.bzl", "java")
+load("@rules_android//rules:processing_pipeline.bzl", "ProviderInfo", "processing_pipeline")
+load("@rules_android//rules/android_local_test:impl.bzl", "finalize")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
+# buildifier: disable=bzl-visibility
+load("//kotlin/internal/jvm:kt_android_local_test.bzl", "make_rule")
+
+# buildifier: disable=bzl-visibility
+load("//kotlin/internal/jvm:kt_android_local_test_impl.bzl", "PROCESSORS")
+
+def _custom_coverage(ctx, **sub_ctxs):
+    if not ctx.configuration.coverage_enabled:
+        return PROCESSORS["CoverageProcessor"](ctx, **sub_ctxs)
+
+    # Analysis-only stand-ins: a real integration obtains the agent from its
+    # toolchain and writes the coverage tool's configuration here.
+    agent = ctx.actions.declare_file(ctx.label.name + "_agent.jar")
+    args = ctx.actions.declare_file(ctx.label.name + "_agent.args")
+    ctx.actions.write(agent, "")
+    ctx.actions.write(args, "")
+    return ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = [],
+            java_start_class = ctx.attr.main_class,
+            coverage_start_class = None,
+            additional_jvm_flags = [
+                "-javaagent:%s=file:%s" % (agent.short_path, args.short_path),
+                "-Dpipeline.flag=" + ctx.attr.pipeline_flag,
+            ],
+        ),
+        runfiles = ctx.runfiles(files = [agent, args]),
+    )
+
+_CUSTOM_PIPELINE = processing_pipeline.make_processing_pipeline(
+    processors = processing_pipeline.replace(PROCESSORS, CoverageProcessor = _custom_coverage),
+    finalize = finalize,
+)
+
+def _custom_impl(ctx):
+    java_package = java.resolve_package_from_label(ctx.label, ctx.attr.custom_package)
+    return processing_pipeline.run(ctx, java_package, _CUSTOM_PIPELINE)
+
+_custom_android_local_test = make_rule(
+    implementation = _custom_impl,
+    attrs = {"pipeline_flag": attr.string(default = "retained")},
+)
+_default_android_local_test = make_rule()
+
+def _coverage_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.true(env, any([a.mnemonic == "KotlinCompile" for a in analysistest.target_actions(env)]))
+    executable = target[DefaultInfo].files_to_run.executable
+    actions = [a for a in analysistest.target_actions(env) if executable in a.outputs.to_list()]
+    asserts.equals(env, 1, len(actions))
+    subs = actions[0].substitutions
+    jacoco = ctx.attr.mode == "jacoco"
+    agent = ctx.attr.mode == "agent"
+
+    asserts.equals(env, "com.google.testing.coverage.JacocoCoverageRunner" if jacoco else "com.example.CustomRunner", subs["%java_start_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_metadata%"]))
+    asserts.equals(env, "export JACOCO_MAIN_CLASS=com.example.CustomRunner" if jacoco else "", subs["%set_jacoco_main_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_java_runfiles_root%"]))
+    asserts.equals(env, agent, "-javaagent:" in subs["%jvm_flags%"])
+    asserts.equals(env, agent, "-Dpipeline.flag=retained" in subs["%jvm_flags%"])
+    asserts.true(env, "-Dbazel.test_suite=com.example.ExampleTest" in subs["%jvm_flags%"])
+    asserts.true(env, "-Drobolectric.offline=true" in subs["%jvm_flags%"])
+    asserts.true(env, "-Duser.flag=retained" in subs["%jvm_flags%"])
+
+    runtime_jars = target[JavaInfo].transitive_runtime_jars.to_list()
+    asserts.equals(env, jacoco, any(["jacoco" in f.basename.lower() for f in runtime_jars]))
+    runfiles = target[DefaultInfo].default_runfiles.files.to_list()
+    agent_files = [f for f in runfiles if f.basename.endswith(("_agent.jar", "_agent.args"))]
+    asserts.equals(env, 2 if agent else 0, len(agent_files))
+    for f in agent_files:
+        asserts.true(env, f.short_path in subs["%jvm_flags%"])
+    asserts.true(env, any([f.basename == target.label.name + "_deploy.jar" for f in runfiles]))
+    if jacoco:
+        asserts.true(env, target.label.name + "_deploy.jar" in subs["%set_jacoco_metadata%"])
+    return analysistest.end(env)
+
+_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": True},
+    attrs = {"mode": attr.string()},
+)
+_no_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": False},
+    attrs = {"mode": attr.string(default = "off")},
+)
+
+def coverage_test_suite(name):
+    """Checks default JaCoCo, custom agent, and coverage-disabled launchers.
+
+    Args:
+      name: Name of the test suite.
+    """
+    tests = []
+    for variant, test_rule in [("default", _default_android_local_test), ("custom", _custom_android_local_test)]:
+        subject = name + "_" + variant + "_subject"
+        test_rule(
+            name = subject,
+            srcs = ["ExampleTest.kt"],
+            custom_package = "com.example",
+            main_class = "com.example.CustomRunner",
+            test_class = "com.example.ExampleTest",
+            jvm_flags = ["-Duser.flag=retained"],
+            tags = ["manual"],
+        )
+        _coverage_test(
+            name = name + "_" + variant,
+            target_under_test = ":" + subject,
+            mode = "jacoco" if variant == "default" else "agent",
+        )
+        _no_coverage_test(
+            name = name + "_" + variant + "_off",
+            target_under_test = ":" + subject,
+        )
+        tests.extend([":" + name + "_" + variant, ":" + name + "_" + variant + "_off"])
+    native.test_suite(name = name, tests = tests)


### PR DESCRIPTION
Separate `kt_android_local_test` coverage runtime selection from Kotlin compilation, using the `CoverageProcessor` introduced in bazelbuild/rules_android#562. A downstream rule can replace that processor and reuse Kotlin resource handling, compilation, deploy-jar creation, launcher generation, and finalization.

The default processor preserves the Kotlin toolchain's JaCoCo runner. The JVM processor consumes its dependencies, entry classes, and JVM flags while retaining the Java security-manager flag. Expose `make_rule` with merged Kotlin attributes and toolchains so custom implementations do not need to copy the rule declaration.

The analysis-test example replaces only `CoverageProcessor` with an inert agent configuration. It covers default/custom pipelines with coverage enabled and disabled, including Kotlin compilation, launcher substitutions, runfiles, custom attributes, and user JVM flags. It introduces no Kover dependency and does not change bytecode instrumentation.

Temporarily pin rules_android to `9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf` in the root module and Android-consuming examples. Overrides are root-only, so example modules need their own pins. Set the tool Java source level to 17 alongside these pins, as required by the newer Android tools. This is independent of rules_kotlin#1729; merging/releasing requires the upstream API, and the archive pins should become a released dependency once available.

Validation (macOS, Bazel 9.2.0):
- `bazel test //src/test/starlark/android_local_test:coverage_tests`: all four analysis tests pass.
- `bazel build //src/test/starlark/android_local_test:coverage_tests_default_subject`: passes, including Kotlin compilation and Android resource processing.
- Buildifier formatting/lint and `git diff --check` pass.

The agent is deliberately an analysis-only stand-in; no custom coverage engine is executed. The full examples/platform matrix remains for CI.
