### PR TITLE
Demonstrate Kover with Android coverage processors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,9 @@ common --incompatible_autoload_externally=
 common --java_runtime_version=remotejdk_17
 common --tool_java_runtime_version=remotejdk_17
 
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17
+
 build --test_output=all
 build --verbose_failures
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,16 @@ bazel_dep(name = "rules_java", version = "8.9.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_android", version = "0.7.3")
 
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)
+
 remote_android_extensions = use_extension(
     "@rules_android//bzlmod_extensions:android_extensions.bzl",
     "remote_android_tools_extensions",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -168,3 +168,13 @@ use_repo(
     "build_bazel_bazel_7_x",
     "build_bazel_bazel_8_x",
 )
+
+# Same agent version as the example in Kover PR #1729.
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "kover_test_agent",
+    downloaded_file_path = "kover-jvm-agent-0.8.3.jar",
+    sha256 = "3c07bdf995edce414d078dbd9725cd78c49f9cce871831264d09fa1f7ea067ed",
+    urls = ["https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kover-jvm-agent/0.8.3/kover-jvm-agent-0.8.3.jar"],
+)

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -27,3 +27,6 @@ build:android_worker \
   --strategy=JavaSourceJar=remote,local \
   --strategy=Turbine=remote,local \
   --strategy=PackageAndroidResources=local
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/android/MODULE.bazel
+++ b/examples/android/MODULE.bazel
@@ -40,3 +40,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/anvil/.bazelrc
+++ b/examples/anvil/.bazelrc
@@ -1,2 +1,5 @@
 common --java_runtime_version=remotejdk_21
 common --tool_java_runtime_version=remotejdk_21
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/anvil/MODULE.bazel
+++ b/examples/anvil/MODULE.bazel
@@ -74,3 +74,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/deps/.bazelrc
+++ b/examples/deps/.bazelrc
@@ -7,3 +7,6 @@ common --toolchain_resolution_debug=.*
 # Required for abseil-cpp which requires C++17
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/deps/MODULE.bazel
+++ b/examples/deps/MODULE.bazel
@@ -29,3 +29,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -14,3 +14,6 @@ common --tool_java_runtime_version=remotejdk_17
 # Required for abseil-cpp which requires C++17
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/jetpack_compose/MODULE.bazel
+++ b/examples/jetpack_compose/MODULE.bazel
@@ -52,3 +52,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/examples/plugin/.bazelrc
+++ b/examples/plugin/.bazelrc
@@ -1,2 +1,5 @@
 common --java_runtime_version=remotejdk_21
 common --tool_java_runtime_version=remotejdk_21
+
+# The pinned rules_android tools require Java 17 source syntax.
+build --tool_java_language_version=17

--- a/examples/plugin/MODULE.bazel
+++ b/examples/plugin/MODULE.bazel
@@ -26,3 +26,13 @@ maven.install(
     use_starlark_android_rules = True,
 )
 use_repo(maven, "maven_rules_kotlin_example")
+
+# CoverageProcessor API from https://github.com/bazelbuild/rules_android/pull/562.
+# Replace this override with a rules_android release once available.
+archive_override(
+    module_name = "rules_android",
+    integrity = "sha256-GCZvGN7DyFBmeOQz0RCzJJUZiln+F8Nk5rwUxPFxQ2U=",
+    strip_prefix = "rules_android-9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf",
+    type = "tar.gz",
+    urls = ["https://codeload.github.com/bazelbuild/rules_android/tar.gz/9e7e6f868e663bbbd3ff07bb2781e12d0d4d3cbf"],
+)

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -48,6 +48,10 @@ load(
     _jvm_deps_utils = "jvm_deps_utils",
 )
 load(
+    "//kotlin/internal/jvm:kover.bzl",
+    _is_kover_enabled = "is_kover_enabled",
+)
+load(
     "//kotlin/internal/jvm:plugins.bzl",
     "is_ksp_processor_generating_java",
     _plugin_mappers = "mappers",
@@ -718,7 +722,7 @@ def _run_kt_builder_action(
     args.add_all("--source_jars", srcs.src_jars + generated_src_jars, omit_if_empty = True)
     args.add_all("--deps_artifacts", deps_artifacts, omit_if_empty = True)
     args.add_all("--kotlin_friend_paths", compile_deps.associate_jars, omit_if_empty = True)
-    args.add("--instrument_coverage", ctx.coverage_instrumented())
+    args.add("--instrument_coverage", ctx.coverage_instrumented() and not _is_kover_enabled(ctx))
 
     # Collect and prepare plugin descriptor for the worker.
     args.add_all(

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -27,6 +27,14 @@ load(
     _compile = "compile",
 )
 load(
+    "//kotlin/internal/jvm:kover.bzl",
+    _create_kover_agent_actions = "create_kover_agent_actions",
+    _create_kover_metadata_action = "create_kover_metadata_action",
+    _get_kover_agent_file = "get_kover_agent_file",
+    _get_kover_jvm_flags = "get_kover_jvm_flags",
+    _is_kover_enabled = "is_kover_enabled",
+)
+load(
     "//kotlin/internal/utils:utils.bzl",
     _utils = "utils",
 )
@@ -207,7 +215,7 @@ def _write_launcher_action(ctx, rjars, main_class, jvm_flags, is_test = False):
     prefix = "" if _is_absolute_target_platform_path(ctx, java_bin_path) else "${JAVA_RUNFILES}/"
     java_bin = "JAVABIN=${JAVABIN:-" + prefix + java_bin_path + "}"
 
-    if ctx.configuration.coverage_enabled:
+    if ctx.configuration.coverage_enabled and not _is_kover_enabled(ctx):
         jacocorunner = ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner
         classpath = ctx.configuration.host_path_separator.join(
             ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + jacocorunner.files.to_list()],
@@ -441,9 +449,22 @@ def kt_jvm_junit_test_impl(ctx):
     runtime_jars = depset(ctx.files._bazel_test_runner, transitive = [providers.java.transitive_runtime_jars])
 
     coverage_runfiles = []
+    coverage_jvm_flags = []
     if ctx.configuration.coverage_enabled:
-        jacocorunner = ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner
-        coverage_runfiles = jacocorunner.files.to_list()
+        if _is_kover_enabled(ctx):
+            agent = _get_kover_agent_file(ctx)
+            output, args = _create_kover_agent_actions(ctx, ctx.label.name)
+            metadata = _create_kover_metadata_action(
+                ctx,
+                ctx.label.name,
+                ctx.attr.deps + ctx.attr.associates,
+                output,
+            )
+            coverage_jvm_flags = _get_kover_jvm_flags(agent, args)
+            coverage_runfiles = [agent, args, metadata]
+        else:
+            jacocorunner = ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner
+            coverage_runfiles = jacocorunner.files.to_list()
 
     test_class = ctx.attr.test_class
 
@@ -462,7 +483,7 @@ def kt_jvm_junit_test_impl(ctx):
     if hasattr(ctx.fragments.java, "default_jvm_opts"):
         jvm_flags = ctx.fragments.java.default_jvm_opts
 
-    jvm_flags.extend(ctx.attr.jvm_flags)
+    jvm_flags.extend(coverage_jvm_flags + ctx.attr.jvm_flags)
     launcher_result = _write_launcher_action(
         ctx,
         runtime_jars,

--- a/kotlin/internal/jvm/kover.bzl
+++ b/kotlin/internal/jvm/kover.bzl
@@ -1,0 +1,180 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kover helpers adapted from rules_kotlin PR #1729.
+
+This draft preserves that proposal's raw report and CLI metadata layout.
+Bazel test-output harvesting and mixed Java/Kotlin instrumentation remain
+separate integration work; a generated build artifact is not a test output.
+"""
+
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    _paths = "paths",
+)
+load("@rules_java//java:defs.bzl", "JavaInfo")
+load(
+    "//kotlin/internal:defs.bzl",
+    _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
+)
+
+def is_kover_enabled(ctx):
+    return ctx.toolchains[_TOOLCHAIN_TYPE].experimental_kover_enabled
+
+def get_kover_agent_file(ctx):
+    """Get the Kover agent runtime file from the toolchain.
+
+    Args:
+        ctx: The rule context.
+
+    Returns:
+        The Kover agent runtime file.
+    """
+    kover_agent = ctx.toolchains[_TOOLCHAIN_TYPE].experimental_kover_agent
+    if not kover_agent:
+        fail("Kover agent wasn't specified in toolchain.")
+
+    return kover_agent
+
+def get_kover_jvm_flags(kover_agent_file, kover_args_file):
+    """Compute the jvm flags used to setup Kover agent.
+
+    Args:
+        kover_agent_file: The Kover agent file.
+        kover_args_file: The Kover arguments file.
+
+    Returns:
+        The flags to be passed separately to the test runner JVM.
+    """
+    jvm_args = [
+        "-Xbootclasspath/a:%s" % (kover_agent_file.short_path),
+        "-javaagent:%s=file:%s" % (kover_agent_file.short_path, kover_args_file.short_path),
+    ]
+    return jvm_args
+
+def _source_to_kover_arg(src):
+    return "--src\n%s" % _paths.dirname(src.short_path)
+
+def _classfile_to_kover_arg(classfile):
+    return "--classfiles\n%s" % classfile.short_path
+
+def _exclude_to_kover_arg(exclude):
+    return "--exclude\n%s" % exclude
+
+def _exclude_annotation_to_kover_arg(exclude_annotation):
+    return "--excludeAnnotation\n%s" % exclude_annotation
+
+def _exclude_inherited_from_to_kover_arg(exclude_inherited_from):
+    return "--excludeInheritedFrom\n%s" % exclude_inherited_from
+
+def create_kover_agent_actions(ctx, name):
+    """Generate the actions needed to emit Kover code coverage metadata file.
+
+    Creates the properly populated arguments input file needed by Kover agent.
+
+    Args:
+        ctx: The rule context.
+        name: The name of the target.
+
+    Returns:
+        A tuple of (kover_output_file, kover_args_file).
+    """
+
+    # declare code coverage raw data binary output file
+    binary_output_name = "%s-kover_report.ic" % name
+    kover_output_file = ctx.actions.declare_file(binary_output_name)
+
+    # Declare an initial output without relying on a shell command so this also
+    # works on Windows. The Kover agent replaces it when the test runs.
+    ctx.actions.write(kover_output_file, "")
+
+    # declare args file - https://kotlin.github.io/kotlinx-kover/jvm-agent/#kover-jvm-arguments-file
+    kover_args_file = ctx.actions.declare_file(
+        "%s-kover.args.txt" % name,
+    )
+    ctx.actions.write(
+        kover_args_file,
+        "report.file=%s" % kover_output_file.short_path,
+    )
+
+    return kover_output_file, kover_args_file
+
+def create_kover_metadata_action(
+        ctx,
+        name,
+        deps,
+        kover_output_file):
+    """Generate kover metadata file needed for invoking kover CLI to generate report.
+
+    More info at: https://kotlin.github.io/kotlinx-kover/cli/
+
+    Args:
+        ctx: The rule context.
+        name: The name of the target.
+        deps: The dependencies to collect coverage for.
+        kover_output_file: The Kover output file.
+
+    Returns:
+        The kover output metadata file.
+    """
+    metadata_output_name = "%s-kover_metadata.txt" % name
+    kover_output_metadata_file = ctx.actions.declare_file(metadata_output_name)
+
+    instrumented_files = depset(transitive = [
+        dep[InstrumentedFilesInfo].instrumented_files
+        for dep in deps
+        if InstrumentedFilesInfo in dep
+    ])
+    runtime_jars = depset(transitive = [
+        dep[JavaInfo].transitive_runtime_jars
+        for dep in deps
+        if JavaInfo in dep
+    ])
+
+    args = ctx.actions.args()
+    args.add("report")
+    args.add(kover_output_file.short_path)
+    args.add("--title")
+    args.add("Code-Coverage Analysis: %s" % ctx.label)
+    args.add_joined(
+        instrumented_files,
+        join_with = "\n",
+        map_each = _source_to_kover_arg,
+        uniquify = True,
+    )
+    args.add_joined(
+        runtime_jars,
+        join_with = "\n",
+        map_each = _classfile_to_kover_arg,
+        uniquify = True,
+    )
+    args.add_joined(
+        ctx.toolchains[_TOOLCHAIN_TYPE].experimental_kover_exclude,
+        join_with = "\n",
+        map_each = _exclude_to_kover_arg,
+    )
+    args.add_joined(
+        ctx.toolchains[_TOOLCHAIN_TYPE].experimental_kover_exclude_annotation,
+        join_with = "\n",
+        map_each = _exclude_annotation_to_kover_arg,
+    )
+    args.add_joined(
+        ctx.toolchains[_TOOLCHAIN_TYPE].experimental_kover_exclude_inherited_from,
+        join_with = "\n",
+        map_each = _exclude_inherited_from_to_kover_arg,
+    )
+
+    ctx.actions.write(kover_output_metadata_file, args)
+
+    return kover_output_metadata_file

--- a/kotlin/internal/jvm/kt_android_local_test.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test.bzl
@@ -55,11 +55,24 @@ _ATTRS = _utils.add_dicts(_BASE_ATTRS, _attrs.runnable_common_attr, {
     ),
 })
 
-kt_android_local_test = _make_rule(
-    implementation = _kt_android_local_test_impl,
-    attrs = _ATTRS,
-    additional_toolchains = [
-        _TOOLCHAIN_TYPE,
-        _JAVA_RUNTIME_TOOLCHAIN_TYPE,
-    ],
-)
+def make_rule(attrs = {}, implementation = _kt_android_local_test_impl, additional_toolchains = []):
+    """Creates a Kotlin Android local test rule with a custom processing pipeline.
+
+    Args:
+      attrs: Additional attributes or overrides for the Kotlin test attributes.
+      implementation: Rule implementation running the processing pipeline.
+      additional_toolchains: Toolchains required by custom processors.
+
+    Returns:
+      A test rule with the Kotlin compilation attributes and toolchains.
+    """
+    return _make_rule(
+        implementation = implementation,
+        attrs = _utils.add_dicts(_ATTRS, attrs),
+        additional_toolchains = [
+            _TOOLCHAIN_TYPE,
+            _JAVA_RUNTIME_TOOLCHAIN_TYPE,
+        ] + additional_toolchains,
+    )
+
+kt_android_local_test = make_rule()

--- a/kotlin/internal/jvm/kt_android_local_test_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test_impl.bzl
@@ -110,7 +110,28 @@ def _process_resources(ctx, java_package, manifest_ctx, **_unused_sub_ctxs):
         value = resources_ctx,
     )
 
-def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
+def _process_coverage(ctx, **_unused_sub_ctxs):
+    """Selects the Kotlin toolchain's coverage runtime independently of compilation."""
+    deps = []
+    if ctx.configuration.coverage_enabled:
+        deps.append(ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner)
+        java_start_class = _JACOCOCO_CLASS
+        coverage_start_class = ctx.attr.main_class
+    else:
+        java_start_class = ctx.attr.main_class
+        coverage_start_class = None
+
+    return _ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = deps,
+            java_start_class = java_start_class,
+            coverage_start_class = coverage_start_class,
+            additional_jvm_flags = [],
+        ),
+    )
+
+def _process_jvm(ctx, resources_ctx, coverage_ctx, **_unused_sub_ctxs):
     """Custom JvmProcessor that handles Kotlin compilation
     """
     _compile.verify_associates_not_duplicated_in_deps(deps = getattr(ctx.attr, "deps", []), associate_deps = getattr(ctx.attr, "associates", []))
@@ -120,16 +141,9 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
     deps = (
         [_get_android_toolchain(ctx).testsupport] +
         getattr(ctx.attr, "associates", []) +
-        getattr(ctx.attr, "deps", [])
+        getattr(ctx.attr, "deps", []) +
+        coverage_ctx.deps
     )
-
-    if ctx.configuration.coverage_enabled:
-        deps.append(ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner)
-        java_start_class = _JACOCOCO_CLASS
-        coverage_start_class = ctx.attr.main_class
-    else:
-        java_start_class = ctx.attr.main_class
-        coverage_start_class = None
 
     # Setup the compile action.
     providers = _compile.kt_jvm_produce_output_jar_actions(
@@ -173,7 +187,7 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
         runfiles.append(filtered_jdeps)
 
     # Append the security manager override
-    jvm_flags = []
+    jvm_flags = list(coverage_ctx.additional_jvm_flags)
     java_runtime = ctx.toolchains[_JAVA_RUNTIME_TOOLCHAIN_TYPE].java_runtime
 
     _java_runtime_version = getattr(java_runtime, "version", 0)
@@ -186,8 +200,8 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
             java_info = java_info,
             providers = providers,
             deps = deps,
-            java_start_class = java_start_class,
-            coverage_start_class = coverage_start_class,
+            java_start_class = coverage_ctx.java_start_class,
+            coverage_start_class = coverage_ctx.coverage_start_class,
             android_properties_file = ctx.file.robolectric_properties_file.short_path,
             additional_jvm_flags = jvm_flags,
         ),
@@ -197,6 +211,7 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
 PROCESSORS = _processing_pipeline.replace(
     _BASE_PROCESSORS,
     ResourceProcessor = _process_resources,
+    CoverageProcessor = _process_coverage,
     JvmProcessor = _process_jvm,
 )
 

--- a/kotlin/internal/jvm/kt_android_local_test_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test_impl.bzl
@@ -69,6 +69,14 @@ load(
     "//kotlin/internal/jvm:jvm_deps.bzl",
     _jvm_deps_utils = "jvm_deps_utils",
 )
+load(
+    "//kotlin/internal/jvm:kover.bzl",
+    _create_kover_agent_actions = "create_kover_agent_actions",
+    _create_kover_metadata_action = "create_kover_metadata_action",
+    _get_kover_agent_file = "get_kover_agent_file",
+    _get_kover_jvm_flags = "get_kover_jvm_flags",
+    _is_kover_enabled = "is_kover_enabled",
+)
 
 _JACOCOCO_CLASS = "com.google.testing.coverage.JacocoCoverageRunner"
 
@@ -112,6 +120,26 @@ def _process_resources(ctx, java_package, manifest_ctx, **_unused_sub_ctxs):
 
 def _process_coverage(ctx, **_unused_sub_ctxs):
     """Selects the Kotlin toolchain's coverage runtime independently of compilation."""
+    if ctx.configuration.coverage_enabled and _is_kover_enabled(ctx):
+        agent = _get_kover_agent_file(ctx)
+        output, args = _create_kover_agent_actions(ctx, ctx.label.name)
+        metadata = _create_kover_metadata_action(
+            ctx,
+            ctx.label.name,
+            ctx.attr.deps + ctx.attr.associates,
+            output,
+        )
+        return _ProviderInfo(
+            name = "coverage_ctx",
+            value = struct(
+                deps = [],
+                java_start_class = ctx.attr.main_class,
+                coverage_start_class = None,
+                additional_jvm_flags = _get_kover_jvm_flags(agent, args),
+            ),
+            runfiles = ctx.runfiles(files = [agent, args, metadata]),
+        )
+
     deps = []
     if ctx.configuration.coverage_enabled:
         deps.append(ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner)

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -107,6 +107,11 @@ def _kotlin_toolchain_impl(ctx):
         empty_jar = ctx.file._empty_jar,
         empty_jdeps = ctx.file._empty_jdeps,
         jacocorunner = ctx.attr.jacocorunner,
+        experimental_kover_enabled = ctx.attr.experimental_kover_enabled,
+        experimental_kover_agent = ctx.file.experimental_kover_agent,
+        experimental_kover_exclude = ctx.attr.experimental_kover_exclude,
+        experimental_kover_exclude_annotation = ctx.attr.experimental_kover_exclude_annotation,
+        experimental_kover_exclude_inherited_from = ctx.attr.experimental_kover_exclude_inherited_from,
         experimental_prune_transitive_deps = ctx.attr._experimental_prune_transitive_deps[BuildSettingInfo].value,
         experimental_prune_transitive_deps_keep_transitive_repositories = ctx.attr._experimental_prune_transitive_deps_keep_transitive_repositories[BuildSettingInfo].value,
         experimental_strict_associate_dependencies = ctx.attr._experimental_strict_associate_dependencies[BuildSettingInfo].value,
@@ -156,6 +161,23 @@ _kt_toolchain = rule(
             enabled via the defines `kt_timings=1` and `kt_trace=1`. These can also be enabled on a per target bases by
             using `tags` attribute defined directly on the rules.""",
             allow_empty = True,
+        ),
+        "experimental_kover_agent": attr.label(
+            doc = "Kover agent JAR used when experimental_kover_enabled is true.",
+            allow_single_file = [".jar"],
+        ),
+        "experimental_kover_enabled": attr.bool(
+            doc = "Use Kover runtime instrumentation for Kotlin tests.",
+            default = False,
+        ),
+        "experimental_kover_exclude": attr.string_list(
+            doc = "Class exclusions for Kover CLI reports.",
+        ),
+        "experimental_kover_exclude_annotation": attr.string_list(
+            doc = "Annotation exclusions for Kover CLI reports.",
+        ),
+        "experimental_kover_exclude_inherited_from": attr.string_list(
+            doc = "Superclass exclusions for Kover CLI reports.",
         ),
         "experimental_build_tools_api": attr.bool(
             doc = "Enables experimental support for Build Tools API integration",
@@ -426,6 +448,11 @@ def define_kt_toolchain(
         experimental_multiplex_sandboxing = None,
         supports_path_mapping = None,
         experimental_build_tools_api = None,
+        experimental_kover_enabled = False,
+        experimental_kover_agent = None,
+        experimental_kover_exclude = None,
+        experimental_kover_exclude_annotation = None,
+        experimental_kover_exclude_inherited_from = None,
         btapi_runtime = None,
         javac_options = Label("//kotlin/internal:default_javac_options"),
         kotlinc_options = Label("//kotlin/internal:default_kotlinc_options"),
@@ -444,6 +471,11 @@ def define_kt_toolchain(
     libraries they need, and the internal compiler plugins in the embeddable dialect.
 
     Args:
+        experimental_kover_enabled: Use runtime Kover instrumentation instead of offline JaCoCo.
+        experimental_kover_agent: Label of the Kover JVM agent JAR.
+        experimental_kover_exclude: Class patterns excluded from Kover CLI reports.
+        experimental_kover_exclude_annotation: Annotation patterns excluded from Kover CLI reports.
+        experimental_kover_exclude_inherited_from: Superclass patterns excluded from Kover CLI reports.
         name: the toolchain name.
         experimental_build_tools_api: `True` enables the Build Tools API compilation for the
             toolchain. Unset, it is `True` when `btapi_runtime` is set and `False` otherwise.
@@ -493,6 +525,11 @@ def define_kt_toolchain(
         experimental_report_unused_deps = experimental_report_unused_deps,
         experimental_reduce_classpath_mode = experimental_reduce_classpath_mode,
         experimental_build_tools_api = experimental_build_tools_api,
+        experimental_kover_enabled = experimental_kover_enabled,
+        experimental_kover_agent = experimental_kover_agent,
+        experimental_kover_exclude = experimental_kover_exclude or [],
+        experimental_kover_exclude_annotation = experimental_kover_exclude_annotation or [],
+        experimental_kover_exclude_inherited_from = experimental_kover_exclude_inherited_from or [],
         btapi_runtime = btapi_runtime,
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,

--- a/src/test/starlark/android_local_test/BUILD.bazel
+++ b/src/test/starlark/android_local_test/BUILD.bazel
@@ -1,3 +1,18 @@
+load("//kotlin:core.bzl", "define_kt_toolchain")
+load("//src/test/starlark/internal/jvm:kover_test.bzl", "kover_test_suite")
 load(":coverage_test.bzl", "coverage_test_suite")
+load(":kover_test.bzl", "kover_pipeline_test_suite")
 
 coverage_test_suite(name = "coverage_tests")
+
+# Opt in with --extra_toolchains=//src/test/starlark/android_local_test:kover_toolchain.
+define_kt_toolchain(
+    name = "kover_toolchain",
+    experimental_kover_agent = "@kover_test_agent//file",
+    experimental_kover_enabled = True,
+    experimental_kover_exclude = ["com.example.generated.*"],
+)
+
+kover_pipeline_test_suite(name = "kover_pipeline_tests")
+
+kover_test_suite(name = "kover_flags_tests")

--- a/src/test/starlark/android_local_test/BUILD.bazel
+++ b/src/test/starlark/android_local_test/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":coverage_test.bzl", "coverage_test_suite")
+
+coverage_test_suite(name = "coverage_tests")

--- a/src/test/starlark/android_local_test/ExampleTest.kt
+++ b/src/test/starlark/android_local_test/ExampleTest.kt
@@ -1,0 +1,16 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.example
+
+class ExampleTest

--- a/src/test/starlark/android_local_test/coverage_test.bzl
+++ b/src/test/starlark/android_local_test/coverage_test.bzl
@@ -1,0 +1,139 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis tests and a make_rule prototype for custom coverage runtimes."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_android//rules:java.bzl", "java")
+load("@rules_android//rules:processing_pipeline.bzl", "ProviderInfo", "processing_pipeline")
+load("@rules_android//rules/android_local_test:impl.bzl", "finalize")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+
+# buildifier: disable=bzl-visibility
+load("//kotlin/internal/jvm:kt_android_local_test.bzl", "make_rule")
+
+# buildifier: disable=bzl-visibility
+load("//kotlin/internal/jvm:kt_android_local_test_impl.bzl", "PROCESSORS")
+
+def _custom_coverage(ctx, **sub_ctxs):
+    if not ctx.configuration.coverage_enabled:
+        return PROCESSORS["CoverageProcessor"](ctx, **sub_ctxs)
+
+    # Analysis-only stand-ins: a real integration obtains the agent from its
+    # toolchain and writes the coverage tool's configuration here.
+    agent = ctx.actions.declare_file(ctx.label.name + "_agent.jar")
+    args = ctx.actions.declare_file(ctx.label.name + "_agent.args")
+    ctx.actions.write(agent, "")
+    ctx.actions.write(args, "")
+    return ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = [],
+            java_start_class = ctx.attr.main_class,
+            coverage_start_class = None,
+            additional_jvm_flags = [
+                "-javaagent:%s=file:%s" % (agent.short_path, args.short_path),
+                "-Dpipeline.flag=" + ctx.attr.pipeline_flag,
+            ],
+        ),
+        runfiles = ctx.runfiles(files = [agent, args]),
+    )
+
+_CUSTOM_PIPELINE = processing_pipeline.make_processing_pipeline(
+    processors = processing_pipeline.replace(PROCESSORS, CoverageProcessor = _custom_coverage),
+    finalize = finalize,
+)
+
+def _custom_impl(ctx):
+    java_package = java.resolve_package_from_label(ctx.label, ctx.attr.custom_package)
+    return processing_pipeline.run(ctx, java_package, _CUSTOM_PIPELINE)
+
+_custom_android_local_test = make_rule(
+    implementation = _custom_impl,
+    attrs = {"pipeline_flag": attr.string(default = "retained")},
+)
+_default_android_local_test = make_rule()
+
+def _coverage_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    asserts.true(env, any([a.mnemonic == "KotlinCompile" for a in analysistest.target_actions(env)]))
+    executable = target[DefaultInfo].files_to_run.executable
+    actions = [a for a in analysistest.target_actions(env) if executable in a.outputs.to_list()]
+    asserts.equals(env, 1, len(actions))
+    subs = actions[0].substitutions
+    jacoco = ctx.attr.mode == "jacoco"
+    agent = ctx.attr.mode == "agent"
+
+    asserts.equals(env, "com.google.testing.coverage.JacocoCoverageRunner" if jacoco else "com.example.CustomRunner", subs["%java_start_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_metadata%"]))
+    asserts.equals(env, "export JACOCO_MAIN_CLASS=com.example.CustomRunner" if jacoco else "", subs["%set_jacoco_main_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_java_runfiles_root%"]))
+    asserts.equals(env, agent, "-javaagent:" in subs["%jvm_flags%"])
+    asserts.equals(env, agent, "-Dpipeline.flag=retained" in subs["%jvm_flags%"])
+    asserts.true(env, "-Dbazel.test_suite=com.example.ExampleTest" in subs["%jvm_flags%"])
+    asserts.true(env, "-Drobolectric.offline=true" in subs["%jvm_flags%"])
+    asserts.true(env, "-Duser.flag=retained" in subs["%jvm_flags%"])
+
+    runtime_jars = target[JavaInfo].transitive_runtime_jars.to_list()
+    asserts.equals(env, jacoco, any(["jacoco" in f.basename.lower() for f in runtime_jars]))
+    runfiles = target[DefaultInfo].default_runfiles.files.to_list()
+    agent_files = [f for f in runfiles if f.basename.endswith(("_agent.jar", "_agent.args"))]
+    asserts.equals(env, 2 if agent else 0, len(agent_files))
+    for f in agent_files:
+        asserts.true(env, f.short_path in subs["%jvm_flags%"])
+    asserts.true(env, any([f.basename == target.label.name + "_deploy.jar" for f in runfiles]))
+    if jacoco:
+        asserts.true(env, target.label.name + "_deploy.jar" in subs["%set_jacoco_metadata%"])
+    return analysistest.end(env)
+
+_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": True},
+    attrs = {"mode": attr.string()},
+)
+_no_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": False},
+    attrs = {"mode": attr.string(default = "off")},
+)
+
+def coverage_test_suite(name):
+    """Checks default JaCoCo, custom agent, and coverage-disabled launchers.
+
+    Args:
+      name: Name of the test suite.
+    """
+    tests = []
+    for variant, test_rule in [("default", _default_android_local_test), ("custom", _custom_android_local_test)]:
+        subject = name + "_" + variant + "_subject"
+        test_rule(
+            name = subject,
+            srcs = ["ExampleTest.kt"],
+            custom_package = "com.example",
+            main_class = "com.example.CustomRunner",
+            test_class = "com.example.ExampleTest",
+            jvm_flags = ["-Duser.flag=retained"],
+            tags = ["manual"],
+        )
+        _coverage_test(
+            name = name + "_" + variant,
+            target_under_test = ":" + subject,
+            mode = "jacoco" if variant == "default" else "agent",
+        )
+        _no_coverage_test(
+            name = name + "_" + variant + "_off",
+            target_under_test = ":" + subject,
+        )
+        tests.extend([":" + name + "_" + variant, ":" + name + "_" + variant + "_off"])
+    native.test_suite(name = name, tests = tests)

--- a/src/test/starlark/android_local_test/kover_test.bzl
+++ b/src/test/starlark/android_local_test/kover_test.bzl
@@ -1,0 +1,105 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checks the real Kover processor without replacing the JVM or stub processors."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//kotlin:android.bzl", "kt_android_local_test")
+load("//kotlin:jvm.bzl", "kt_jvm_test")
+
+_TOOLCHAIN = "//src/test/starlark/android_local_test:kover_toolchain"
+
+def _test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    actions = analysistest.target_actions(env)
+    executable = target[DefaultInfo].files_to_run.executable
+    launcher = [a for a in actions if executable in a.outputs.to_list()][0]
+    subs = launcher.substitutions
+    enabled = ctx.attr.enabled
+    asserts.equals(env, "com.google.testing.junit.runner.BazelTestRunner", subs["%java_start_class%"])
+    asserts.equals(env, "", subs["%set_jacoco_main_class%"])
+    asserts.equals(env, "", subs["%set_jacoco_metadata%"])
+    asserts.equals(env, enabled, "-javaagent:" in subs["%jvm_flags%"])
+    asserts.equals(env, enabled, "-Xbootclasspath/a:" in subs["%jvm_flags%"])
+    asserts.true(env, "-Duser.flag=retained" in subs["%jvm_flags%"])
+    if ctx.attr.android:
+        asserts.true(env, "-Djava.security.manager=allow" in subs["%jvm_flags%"])
+    compile = [a for a in actions if a.mnemonic == "KotlinCompile"][0]
+    args = compile.argv
+    asserts.equals(env, "false", args[args.index("--instrument_coverage") + 1])
+    asserts.false(env, any(["jacoco" in f.basename.lower() for f in target[JavaInfo].transitive_runtime_jars.to_list()]))
+    runfiles = target[DefaultInfo].default_runfiles.files.to_list()
+    files = [f for f in runfiles if f.basename.endswith(("-kover.args.txt", "-kover_metadata.txt", "kover-jvm-agent-0.8.3.jar"))]
+    asserts.equals(env, 3 if enabled else 0, len(files))
+    if enabled:
+        agent_args = [a for a in actions if any([f.basename.endswith("-kover.args.txt") for f in a.outputs.to_list()])][0]
+        asserts.true(env, "report.file=" in agent_args.content)
+        for f in files:
+            if not f.basename.endswith("-kover_metadata.txt"):
+                asserts.true(env, f.short_path in subs["%jvm_flags%"])
+    return analysistest.end(env)
+
+_enabled_test = analysistest.make(
+    _test_impl,
+    config_settings = {
+        "//command_line_option:collect_code_coverage": True,
+        "//command_line_option:extra_toolchains": [_TOOLCHAIN],
+        "//command_line_option:instrumentation_filter": "//src/test/starlark/android_local_test",
+        "//command_line_option:instrument_test_targets": True,
+    },
+    attrs = {"enabled": attr.bool(default = True), "android": attr.bool(default = True)},
+)
+_disabled_test = analysistest.make(
+    _test_impl,
+    config_settings = {
+        "//command_line_option:collect_code_coverage": False,
+        "//command_line_option:extra_toolchains": [_TOOLCHAIN],
+    },
+    attrs = {"enabled": attr.bool(default = False), "android": attr.bool(default = True)},
+)
+
+def kover_pipeline_test_suite(name):
+    """Tests Kover under coverage and the normal runner when coverage is disabled.
+
+    Args:
+        name: Name of the test suite.
+    """
+    subject = name + "_subject"
+    kt_android_local_test(
+        name = subject,
+        srcs = ["ExampleTest.kt"],
+        custom_package = "com.example",
+        test_class = "com.example.ExampleTest",
+        jvm_flags = ["-Duser.flag=retained"],
+        tags = ["manual"],
+    )
+    _enabled_test(name = name + "_enabled", target_under_test = ":" + subject)
+    _disabled_test(name = name + "_disabled", target_under_test = ":" + subject)
+    kt_jvm_test(
+        name = subject + "_jvm",
+        srcs = ["ExampleTest.kt"],
+        test_class = "com.example.ExampleTest",
+        jvm_flags = ["-Duser.flag=retained"],
+        tags = ["manual"],
+    )
+
+    # The JVM launcher uses a native executable on Windows, not substitutions.
+    jvm_compatibility = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    })
+    _enabled_test(target_compatible_with = jvm_compatibility, name = name + "_jvm_enabled", target_under_test = ":" + subject + "_jvm", android = False)
+    _disabled_test(target_compatible_with = jvm_compatibility, name = name + "_jvm_disabled", target_under_test = ":" + subject + "_jvm", android = False)
+    native.test_suite(name = name, tests = [name + suffix for suffix in ["_enabled", "_disabled", "_jvm_enabled", "_jvm_disabled"]])

--- a/src/test/starlark/internal/jvm/kover_test.bzl
+++ b/src/test/starlark/internal/jvm/kover_test.bzl
@@ -1,0 +1,74 @@
+# Copyright 2024 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Kover code coverage integration."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//kotlin/internal/jvm:kover.bzl", "get_kover_jvm_flags")
+
+def _get_kover_jvm_flags_test_impl(ctx):
+    """Test that get_kover_jvm_flags generates correct JVM agent flags including bootclasspath."""
+    env = unittest.begin(ctx)
+
+    # Create mock file objects with short_path attribute
+    mock_agent_file = struct(short_path = "external/kover/kover-jvm-agent.jar")
+    mock_args_file = struct(short_path = "bazel-out/k8-fastbuild/bin/test-kover.args.txt")
+
+    result = get_kover_jvm_flags(mock_agent_file, mock_args_file)
+
+    # Both flags must remain separate JVM arguments.
+    expected = [
+        "-Xbootclasspath/a:external/kover/kover-jvm-agent.jar",
+        "-javaagent:external/kover/kover-jvm-agent.jar=file:bazel-out/k8-fastbuild/bin/test-kover.args.txt",
+    ]
+    asserts.equals(env, expected, result)
+
+    return unittest.end(env)
+
+get_kover_jvm_flags_test = unittest.make(_get_kover_jvm_flags_test_impl)
+
+def _kover_jvm_flags_format_test_impl(ctx):
+    """Test JVM flags format with different path patterns."""
+    env = unittest.begin(ctx)
+
+    # Test with workspace-relative path
+    mock_agent = struct(short_path = "maven/kover-agent-1.0.jar")
+    mock_args = struct(short_path = "pkg/test.args")
+
+    result = get_kover_jvm_flags(mock_agent, mock_args)
+
+    # Verify both independently tokenized flags.
+    asserts.equals(env, 2, len(result))
+    asserts.true(env, result[0].startswith("-Xbootclasspath/a:"))
+    asserts.true(env, result[1].startswith("-javaagent:"))
+    asserts.true(env, "=file:" in result[1])
+    asserts.true(env, result[1].endswith("pkg/test.args"))
+
+    return unittest.end(env)
+
+kover_jvm_flags_format_test = unittest.make(_kover_jvm_flags_format_test_impl)
+
+def kover_test_suite(name):
+    """Create the test suite for Kover integration tests.
+
+    Args:
+        name: The name of the test suite.
+    """
+    unittest.suite(
+        name,
+        get_kover_jvm_flags_test,
+        kover_jvm_flags_format_test,
+    )


### PR DESCRIPTION
Draft follow-up to #1737, demonstrating how the latest open Kover proposal, #1729 (reviewed at `17b4bd69506569a471d06bb42eccbb5c1a27b839`), fits into the extracted Android test pipeline.

Adapt #1729's Kover agent helpers, toolchain configuration, JVM test setup, and offline-instrumentation switch. For Android local tests, configure Kover entirely in `CoverageProcessor`: provide the agent flags/runfiles, keep the normal test runner, and omit JaCoCo runtime setup. The default Kotlin JVM processor and rules_android stub/deploy/finalization processors are reused unchanged.

The Android implementation adds 28 lines, compared with 191 additions in #1729. None of its copied stub-generation, test-class inference, classpath, or JVM-flag helpers are needed. This draft also does not add another rule factory or wrapper.

This PR depends on #1737. Because that branch lives in a fork, this upstream draft targets master and includes its prerequisite changes. Review only the Kover layer using the [incremental comparison](https://github.com/Bencodes/rules_kotlin/compare/support-pluggable-android-local-test-coverage-pipelines...demonstrate-kover-with-android-coverage-processors).

Validation on macOS with Bazel 9.2.0:
- All 10 tests in `//src/test/starlark/android_local_test:all` pass: existing default/custom pipeline cases, Kover Android/JVM coverage-on/off cases, and agent-flag unit tests.
- Built `//src/test/starlark/android_local_test:kover_pipeline_tests_subject` with coverage enabled, test instrumentation selected, and `--extra_toolchains=//src/test/starlark/android_local_test:kover_toolchain`. The pinned agent is Kover 0.8.3, matching #1729.
- Analysis checks verify both agent flags, runfiles, the normal runner, absence of JaCoCo launcher setup/runtime jars, and `--instrument_coverage false` on Kotlin compilation.

Scope and remaining work: this is a pipeline integration prototype, not a claim of complete coverage reporting. It preserves #1729's raw report/CLI metadata layout; collecting raw reports as Bazel test outputs, metadata portability, and mixed Java/Kotlin instrumentation still need resolution. No end-to-end report generation was validated. JVM launcher-substitution tests are skipped on Windows, where the launcher is native.
